### PR TITLE
Expand CI build matrix to Ubuntu ARM, macOS, and Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,13 +26,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest] # TODO(fpedd): Enable more platforms: windows-latest, macos-15-intel, macos-latest
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
       - uses: pypa/cibuildwheel@v2.22
       - uses: actions/upload-artifact@v4
         with:
-          name: cibw-wheels-${{ matrix.os }}
+          name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
           path: ./wheelhouse/*.whl
 
   publish:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,11 @@ skip = "*-musllinux_*"
 # test-command = "pytest {project}/tests/unit -x --no-header -q"
 
 [tool.cibuildwheel.linux]
+archs = ["auto"]
 before-all = "yum install -y cmake || apk add cmake"
+
+[tool.cibuildwheel.macos]
+archs = ["arm64"]
 
 [tool.ruff]
 line-length = 88


### PR DESCRIPTION
Add ubuntu-24.04-arm, macos-latest, and windows-latest to the cibuildwheel build matrix. Configure architecture settings for Linux (auto) and macOS (arm64), and fix artifact name collisions by including job-index.