### PR TITLE
Add IdType cross-reference comments and fix registry docstring

### DIFF
--- a/src/cpp/primitives/id_type.hpp
+++ b/src/cpp/primitives/id_type.hpp
@@ -12,6 +12,7 @@
 
 namespace omnimalloc {
 
+// Must match IdType in src/python/omnimalloc/primitives/allocation.py
 using IdType = std::variant<int64_t, std::string>;
 
 struct IdTypeHash {

--- a/src/python/omnimalloc/common/registry.py
+++ b/src/python/omnimalloc/common/registry.py
@@ -12,8 +12,9 @@ from typing_extensions import Self
 class Registered(ABC):
     """Mixin for auto-registering and managing subclasses.
 
-    Any direct subclass of will maintain its own registry. Any subclass of that
-    subclass that's not abstract will be registered in the subclass's registry.
+    Any direct subclass of Registered will maintain its own registry. Any
+    subclass of that subclass that's not abstract will be registered in the
+    direct subclass's registry.
     """
 
     _registry: ClassVar[dict[str, type[Self]]]

--- a/src/python/omnimalloc/primitives/allocation.py
+++ b/src/python/omnimalloc/primitives/allocation.py
@@ -5,6 +5,7 @@
 from omnimalloc._cpp import Allocation, BufferKind
 
 # Type alias for allocation identifiers (int or str)
+# Must match IdType in src/cpp/primitives/id_type.hpp
 IdType = int | str
 
 __all__ = ["Allocation", "BufferKind", "IdType"]


### PR DESCRIPTION
Add comments linking the C++ and Python IdType definitions to each other, and fix a missing word in the Registered mixin docstring.