### PR TITLE
Source version from git tags via setuptools-scm

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
@@ -29,6 +31,8 @@ jobs:
         os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
       - uses: pypa/cibuildwheel@v2.22
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: sudo apt-get update && sudo apt-get install -y clang-format
       - uses: astral-sh/setup-uv@v5
         with:
@@ -38,6 +40,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -77,6 +81,8 @@ jobs:
             python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -95,6 +101,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
@@ -112,6 +120,8 @@ jobs:
     timeout-minutes: 60
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - run: sudo apt-get update && sudo apt-get install -y clang-tidy iwyu
       - uses: astral-sh/setup-uv@v5
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,14 @@
 cmake_minimum_required(VERSION 3.18...3.30)
+
+# Version is sourced from setuptools-scm via scikit-build-core (git tags). This
+# fallback only applies for standalone CMake calls, not using the build backend.
+if(NOT DEFINED SKBUILD_PROJECT_VERSION)
+  set(SKBUILD_PROJECT_VERSION "0.0.0")
+endif()
+
 project(
   OmniMalloc
-  VERSION 0.4.0 # Also update pyproject.toml
+  VERSION ${SKBUILD_PROJECT_VERSION}
   LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["scikit-build-core>=0.11", "nanobind>=2.0"]
+requires = ["scikit-build-core>=0.11", "nanobind>=2.0", "setuptools-scm>=8"]
 build-backend = "scikit_build_core.build"
 
 [project]
 name = "omnimalloc"
-version = "0.4.0" # Also update CMakeLists.txt
+dynamic = ["version"]
 description = "Your one-stop shop for static memory allocation."
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.10"
@@ -64,6 +64,11 @@ cmake.build-type = "Release"                         # TODO(fpedd): Cross-check 
 build-dir = "build/{wheel_tag}"
 sdist.include = ["src/cpp/**"]
 sdist.exclude = [".github", "notebooks", "external"]
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+
+# Version is derived from git tags (vX.Y.Z); the empty table enables the
+# setuptools-scm defaults, e.g. 0.3.1.dev3+ga8f8686 between releases.
+[tool.setuptools_scm]
 
 [tool.cibuildwheel]
 build = "cp310-* cp311-* cp312-* cp313-*"

--- a/uv.lock
+++ b/uv.lock
@@ -1551,7 +1551,6 @@ wheels = [
 
 [[package]]
 name = "omnimalloc"
-version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },


### PR DESCRIPTION
Eliminates the dual-update workflow where pyproject.toml and CMakeLists.txt had to be edited together for every release. The version now flows from `git tag vX.Y.Z` through setuptools-scm and scikit-build-core into CMake via `SKBUILD_PROJECT_VERSION`, so both the Python package metadata and CMake's `PROJECT_VERSION` read the same value. Between releases, builds get a PEP 440 dev version automatically (e.g. `0.4.1.dev3+ga8f8686`); exact tag checkouts resolve to the clean tag version (e.g. `0.5.0`).

Also sets `fetch-depth: 0` on all CI checkout steps: setuptools-scm needs the tags to derive the version, and the default shallow checkout would silently produce bogus `0.0.post1.dev*` versions on every non-release build.