### PR TITLE
Add tiling and pinwheel benchmark sources

### DIFF
--- a/src/python/omnimalloc/benchmark/sources/__init__.py
+++ b/src/python/omnimalloc/benchmark/sources/__init__.py
@@ -11,6 +11,8 @@ from .generator import UniformSource as UniformSource
 from .huggingface import HuggingfaceSource as HuggingfaceSource
 from .minimalloc import MinimallocSource as MinimallocSource
 from .minimalloc import MinimallocSubset as MinimallocSubset
+from .pinwheel import PinwheelSource as PinwheelSource
+from .tiling import TilingSource as TilingSource
 from .utils import AVAILABLE_SOURCES as AVAILABLE_SOURCES
 from .utils import DEFAULT_SOURCE as DEFAULT_SOURCE
 from .utils import get_available_sources as get_available_sources

--- a/src/python/omnimalloc/benchmark/sources/pinwheel.py
+++ b/src/python/omnimalloc/benchmark/sources/pinwheel.py
@@ -1,0 +1,60 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import random
+
+from .tiling_base import TilingBase, _Tile
+
+
+class PinwheelSource(TilingBase):
+    """Generate non-guillotine packing problems with a known, tight optimum.
+
+    The adversarial sibling of ``TilingSource``: it splits each tile into a
+    pinwheel — a central rectangle ringed by four blades in 90-degree
+    rotational symmetry. No straight line crosses the whole rectangle without
+    slicing a blade, so the packing is non-guillotine and allocators that lean
+    on decomposition or canonical guillotine search cannot shortcut to the
+    optimum. Each split turns one tile into five (net ``+4``), so
+    ``num_allocations`` is rounded up to the nearest ``1 + 4k``. See
+    ``TilingBase`` for the construction and optimality guarantee.
+    """
+
+    def __init__(
+        self,
+        num_allocations: int = 129,
+        capacity: int = 1024 * 1024,
+        makespan: int = 1024 * 1024,
+        min_size: int = 1024,
+        min_duration: int = 1,
+        seed: int | None = 42,
+    ) -> None:
+        if capacity < 3 * min_size:
+            raise ValueError("capacity must be >= 3 * min_size to seat a pinwheel")
+        if makespan < 3 * min_duration:
+            raise ValueError("makespan must be >= 3 * min_duration to seat a pinwheel")
+        super().__init__(
+            num_allocations, capacity, makespan, min_size, min_duration, seed
+        )
+
+    def _can_split(self, tile: _Tile) -> bool:
+        return (
+            tile.end - tile.start >= 3 * self.min_duration
+            and tile.size >= 3 * self.min_size
+        )
+
+    def _split(self, tile: _Tile, rng: random.Random) -> list[_Tile]:
+        """Split a tile into a five-piece pinwheel (center + four blades)."""
+        t0, t1, m0 = tile.start, tile.end, tile.offset
+        width, height = t1 - t0, tile.size
+        m1 = m0 + height
+        # Blade thicknesses; bounds keep all five children >= the minima.
+        p = rng.randint(self.min_duration, (width - self.min_duration) // 2)
+        q = rng.randint(self.min_size, (height - self.min_size) // 2)
+        return [
+            _Tile(t0, t1 - p, m0, q),  # bottom
+            _Tile(t1 - p, t1, m0, height - q),  # right
+            _Tile(t0 + p, t1, m1 - q, q),  # top
+            _Tile(t0, t0 + p, m0 + q, height - q),  # left
+            _Tile(t0 + p, t1 - p, m0 + q, height - 2 * q),  # center
+        ]

--- a/src/python/omnimalloc/benchmark/sources/tiling.py
+++ b/src/python/omnimalloc/benchmark/sources/tiling.py
@@ -1,0 +1,71 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import random
+
+from .tiling_base import TilingBase, _Tile
+
+
+class TilingSource(TilingBase):
+    """Generate hard packing problems via recursive guillotine cuts.
+
+    Every split runs edge to edge, so the optimum is always recoverable by
+    recursive divide-and-conquer (the guillotine sibling of ``PinwheelSource``).
+    ``mem_cut_prob`` tunes temporal contention (and thus hardness) by biasing
+    cuts toward the memory axis. See ``TilingBase`` for the construction and
+    optimality guarantee.
+    """
+
+    def __init__(
+        self,
+        num_allocations: int = 128,
+        capacity: int = 1024 * 1024,
+        makespan: int = 1024 * 1024,
+        min_size: int = 1024,
+        min_duration: int = 1,
+        mem_cut_prob: float = 0.5,
+        seed: int | None = 42,
+    ) -> None:
+        if capacity < min_size:
+            raise ValueError("capacity must be >= min_size")
+        if makespan < min_duration:
+            raise ValueError("makespan must be >= min_duration")
+        if not 0.0 <= mem_cut_prob <= 1.0:
+            raise ValueError("mem_cut_prob must be in [0, 1]")
+        super().__init__(
+            num_allocations, capacity, makespan, min_size, min_duration, seed
+        )
+        self.mem_cut_prob = mem_cut_prob
+
+    def _can_split_time(self, tile: _Tile) -> bool:
+        return tile.end - tile.start >= 2 * self.min_duration
+
+    def _can_split_mem(self, tile: _Tile) -> bool:
+        return tile.size >= 2 * self.min_size
+
+    def _can_split(self, tile: _Tile) -> bool:
+        return self._can_split_time(tile) or self._can_split_mem(tile)
+
+    def _split(self, tile: _Tile, rng: random.Random) -> list[_Tile]:
+        can_mem = self._can_split_mem(tile)
+        can_time = self._can_split_time(tile)
+
+        cut_mem = rng.random() < self.mem_cut_prob if can_mem and can_time else can_mem
+
+        if cut_mem:
+            cut = rng.randint(
+                tile.offset + self.min_size,
+                tile.offset + tile.size - self.min_size,
+            )
+            left = _Tile(tile.start, tile.end, tile.offset, cut - tile.offset)
+            right = _Tile(tile.start, tile.end, cut, tile.offset + tile.size - cut)
+        else:
+            cut = rng.randint(
+                tile.start + self.min_duration,
+                tile.end - self.min_duration,
+            )
+            left = _Tile(tile.start, cut, tile.offset, tile.size)
+            right = _Tile(cut, tile.end, tile.offset, tile.size)
+
+        return [left, right]

--- a/src/python/omnimalloc/benchmark/sources/tiling_base.py
+++ b/src/python/omnimalloc/benchmark/sources/tiling_base.py
@@ -1,0 +1,113 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import random
+from abc import abstractmethod
+from dataclasses import dataclass
+
+from omnimalloc.primitives import Allocation, Pool
+
+from .base import BaseSource
+
+
+@dataclass(frozen=True)
+class _Tile:
+    """A leaf rectangle in the (time x memory) plane.
+
+    ``offset`` is the leaf's memory position in the ground-truth packing; it is
+    discarded when handed to an allocator but kept for validation/reference.
+    """
+
+    start: int
+    end: int
+    offset: int
+    size: int
+
+
+class TilingBase(BaseSource):
+    """Reverse-constructed packing problems with a known, tight optimum.
+
+    A ``capacity x makespan`` rectangle is recursively split into leaf tiles
+    until ``num_allocations`` is reached; each leaf becomes one allocation with
+    its time span and memory height. Because the leaves perfectly tile the
+    rectangle, peak pressure equals ``capacity`` exactly, so ``capacity`` is a
+    provably achievable optimum. Subclasses supply the cut geometry via
+    ``_can_split`` and ``_split``; sweeping ``num_allocations`` yields a
+    difficulty ladder.
+    """
+
+    def __init__(
+        self,
+        num_allocations: int,
+        capacity: int,
+        makespan: int,
+        min_size: int,
+        min_duration: int,
+        seed: int | None,
+    ) -> None:
+        super().__init__(num_allocations=num_allocations)
+        if min_size <= 0:
+            raise ValueError("min_size must be positive")
+        if min_duration <= 0:
+            raise ValueError("min_duration must be positive")
+        self.capacity = capacity
+        self.makespan = makespan
+        self.min_size = min_size
+        self.min_duration = min_duration
+        self.seed = seed
+
+    @abstractmethod
+    def _can_split(self, tile: _Tile) -> bool: ...
+
+    @abstractmethod
+    def _split(self, tile: _Tile, rng: random.Random) -> list[_Tile]:
+        """Split a tile into children that exactly tile it."""
+
+    def _build_tiles(self, num: int, rng: random.Random) -> list[_Tile]:
+        if num <= 0:
+            return []
+        tiles = [_Tile(0, self.makespan, 0, self.capacity)]
+        while len(tiles) < num:
+            splittable = [i for i, t in enumerate(tiles) if self._can_split(t)]
+            if not splittable:
+                raise ValueError(f"cannot reach {num} allocations with given minima")
+            # Weight by area so larger tiles split first, yielding balanced
+            # layouts rather than a few dominant blocks plus many slivers.
+            weights = [
+                (tiles[i].end - tiles[i].start) * tiles[i].size for i in splittable
+            ]
+            idx = rng.choices(splittable, weights=weights, k=1)[0]
+            tiles[idx : idx + 1] = self._split(tiles[idx], rng)
+        return tiles
+
+    def _tile_allocations(
+        self, num_allocations: int | None, skip: int, with_offsets: bool
+    ) -> tuple[Allocation, ...]:
+        num = num_allocations if num_allocations is not None else self.num_allocations
+        seed = None if self.seed is None else self.seed + skip
+        tiles = self._build_tiles(num, random.Random(seed))
+        return tuple(
+            Allocation(
+                id=skip + i,
+                size=t.size,
+                start=t.start,
+                end=t.end,
+                offset=t.offset if with_offsets else None,
+            )
+            for i, t in enumerate(tiles)
+        )
+
+    def get_allocations(
+        self, num_allocations: int | None = None, skip: int = 0
+    ) -> tuple[Allocation, ...]:
+        return self._tile_allocations(num_allocations, skip, with_offsets=False)
+
+    def get_ground_truth_pool(
+        self, num_allocations: int | None = None, skip: int = 0
+    ) -> Pool:
+        """Return the pool with the construction (zero-fragmentation) offsets."""
+        if self.seed is None:
+            raise ValueError("ground truth requires a fixed seed")
+        allocations = self._tile_allocations(num_allocations, skip, with_offsets=True)
+        return Pool(id=f"{self.name()}_ground_truth", allocations=allocations)

--- a/src/python/omnimalloc/common/registry.py
+++ b/src/python/omnimalloc/common/registry.py
@@ -31,7 +31,10 @@ class Registered(ABC):
             return
 
         # Skip abstract classes from registration
-        if getattr(cls, "__abstractmethods__", None):
+        if any(
+            getattr(getattr(cls, name, None), "__isabstractmethod__", False)
+            for name in dir(cls)
+        ):
             return
 
         # Child class - register in parent's registry

--- a/tests/unit/benchmark/sources/test_pinwheel.py
+++ b/tests/unit/benchmark/sources/test_pinwheel.py
@@ -1,0 +1,123 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+from omnimalloc import run_allocation, validate_allocation
+from omnimalloc.benchmark.sources import BaseSource
+from omnimalloc.benchmark.sources.pinwheel import PinwheelSource
+from omnimalloc.primitives import Allocation, Pool
+from omnimalloc.primitives.utils import get_pressure
+
+
+def _signatures(allocations: tuple[Allocation, ...]) -> list[tuple[int, int, int]]:
+    return [(a.start, a.end, a.size) for a in allocations]
+
+
+def _has_guillotine_cut(pool: Pool) -> bool:
+    allocs = pool.allocations
+    t_lo, t_hi = min(a.start for a in allocs), max(a.end for a in allocs)
+    m_lo, m_hi = min(a.offset for a in allocs), max(a.offset + a.size for a in allocs)
+    times = {a.start for a in allocs} | {a.end for a in allocs}
+    mems = {a.offset for a in allocs} | {a.offset + a.size for a in allocs}
+    for t in times:
+        if t_lo < t < t_hi and not any(a.start < t < a.end for a in allocs):
+            return True
+    for m in mems:
+        if m_lo < m < m_hi and not any(
+            a.offset < m < a.offset + a.size for a in allocs
+        ):
+            return True
+    return False
+
+
+def test_pinwheel_source_is_registered() -> None:
+    assert "pinwheel_source" in BaseSource.registry()
+    assert BaseSource.get("pinwheel_source") is PinwheelSource
+
+
+def test_pinwheel_count_rounds_up_to_pinwheel_size() -> None:
+    allocations = PinwheelSource(num_allocations=64).get_allocations()
+    assert len(allocations) == 65
+    assert (len(allocations) - 1) % 4 == 0
+
+
+@pytest.mark.parametrize("num", [5, 17, 65, 257, 513])
+def test_pinwheel_optimum_is_tight(num: int) -> None:
+    capacity = 1024 * 1024
+    source = PinwheelSource(num_allocations=num, capacity=capacity)
+    allocations = source.get_allocations()
+    assert get_pressure(allocations) == capacity
+
+
+def test_pinwheel_allocations_fit_within_makespan() -> None:
+    makespan = 4096
+    source = PinwheelSource(num_allocations=64, makespan=makespan, min_size=1)
+    for alloc in source.get_allocations():
+        assert 0 <= alloc.start < alloc.end <= makespan
+
+
+def test_pinwheel_respects_min_size() -> None:
+    source = PinwheelSource(num_allocations=256, min_size=2048)
+    assert all(a.size >= 2048 for a in source.get_allocations())
+
+
+def test_pinwheel_is_deterministic_per_seed() -> None:
+    a = PinwheelSource(num_allocations=129, seed=7).get_allocations()
+    b = PinwheelSource(num_allocations=129, seed=7).get_allocations()
+    c = PinwheelSource(num_allocations=129, seed=8).get_allocations()
+    assert _signatures(a) == _signatures(b)
+    assert _signatures(a) != _signatures(c)
+
+
+def test_pinwheel_distinct_pools_differ() -> None:
+    source = PinwheelSource(num_allocations=33)
+    pools = source.get_pools(num_pools=2)
+    assert len(pools) == 2
+    assert _signatures(pools[0].allocations) != _signatures(pools[1].allocations)
+
+
+def test_pinwheel_rejects_capacity_too_small() -> None:
+    with pytest.raises(ValueError, match="capacity"):
+        PinwheelSource(capacity=2048, min_size=1024)
+
+
+def test_pinwheel_rejects_makespan_too_small() -> None:
+    with pytest.raises(ValueError, match="makespan"):
+        PinwheelSource(makespan=2, min_duration=1)
+
+
+def test_pinwheel_rejects_nonpositive_min_size() -> None:
+    with pytest.raises(ValueError, match="min_size"):
+        PinwheelSource(min_size=0)
+
+
+def test_pinwheel_ground_truth_is_valid_and_optimal() -> None:
+    capacity = 1024 * 1024
+    source = PinwheelSource(num_allocations=200, capacity=capacity)
+    pool = source.get_ground_truth_pool()
+
+    validate_allocation(pool)
+    assert pool.is_allocated
+    assert pool.size == capacity
+    assert pool.pressure == capacity
+
+
+def test_pinwheel_ground_truth_matches_get_allocations() -> None:
+    source = PinwheelSource(num_allocations=64)
+    truth = source.get_ground_truth_pool()
+    allocs = source.get_allocations()
+    assert _signatures(truth.allocations) == _signatures(allocs)
+
+
+def test_pinwheel_packing_is_non_guillotine() -> None:
+    pool = PinwheelSource(num_allocations=64).get_ground_truth_pool()
+    assert not _has_guillotine_cut(pool)
+
+
+def test_pinwheel_no_allocator_beats_the_optimum() -> None:
+    capacity = 1024 * 1024
+    source = PinwheelSource(num_allocations=150, capacity=capacity)
+    pool = source.get_pool()
+    allocated = run_allocation(pool, "greedy_by_size_allocator_cpp", validate=True)
+    assert allocated.size >= capacity

--- a/tests/unit/benchmark/sources/test_tiling.py
+++ b/tests/unit/benchmark/sources/test_tiling.py
@@ -1,0 +1,133 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+from omnimalloc import run_allocation, validate_allocation
+from omnimalloc.benchmark.sources import BaseSource
+from omnimalloc.benchmark.sources.tiling import TilingSource
+from omnimalloc.primitives import Allocation
+from omnimalloc.primitives.utils import get_pressure
+
+
+def _signatures(allocations: tuple[Allocation, ...]) -> list[tuple[int, int, int]]:
+    return [(a.start, a.end, a.size) for a in allocations]
+
+
+def test_tiling_source_is_registered() -> None:
+    assert "tiling_source" in BaseSource.registry()
+    assert BaseSource.get("tiling_source") is TilingSource
+
+
+def test_tiling_source_produces_requested_count() -> None:
+    source = TilingSource(num_allocations=128)
+    allocations = source.get_allocations()
+    assert len(allocations) == 128
+
+
+@pytest.mark.parametrize("num", [1, 16, 64, 256, 512])
+def test_tiling_optimum_is_tight(num: int) -> None:
+    capacity = 1024 * 1024
+    source = TilingSource(num_allocations=num, capacity=capacity)
+    allocations = source.get_allocations()
+    assert get_pressure(allocations) == capacity
+
+
+def test_tiling_allocations_fit_within_makespan() -> None:
+    makespan = 4096
+    source = TilingSource(num_allocations=64, makespan=makespan, min_size=1)
+    for alloc in source.get_allocations():
+        assert 0 <= alloc.start < alloc.end <= makespan
+
+
+def test_tiling_respects_min_size() -> None:
+    source = TilingSource(num_allocations=256, min_size=2048)
+    assert all(a.size >= 2048 for a in source.get_allocations())
+
+
+def test_tiling_zero_requested_returns_empty() -> None:
+    assert TilingSource().get_allocations(num_allocations=0) == ()
+
+
+def test_tiling_is_deterministic_per_seed() -> None:
+    a = TilingSource(num_allocations=128, seed=7).get_allocations()
+    b = TilingSource(num_allocations=128, seed=7).get_allocations()
+    c = TilingSource(num_allocations=128, seed=8).get_allocations()
+    assert _signatures(a) == _signatures(b)
+    assert _signatures(a) != _signatures(c)
+
+
+def test_tiling_distinct_pools_differ() -> None:
+    source = TilingSource(num_allocations=32)
+    pools = source.get_pools(num_pools=2)
+    assert len(pools) == 2
+    assert _signatures(pools[0].allocations) != _signatures(pools[1].allocations)
+
+
+def test_tiling_rejects_invalid_mem_cut_prob() -> None:
+    with pytest.raises(ValueError, match="mem_cut_prob"):
+        TilingSource(mem_cut_prob=1.5)
+
+
+def test_tiling_rejects_capacity_below_min_size() -> None:
+    with pytest.raises(ValueError, match="capacity"):
+        TilingSource(capacity=10, min_size=1024)
+
+
+def test_tiling_rejects_nonpositive_min_size() -> None:
+    with pytest.raises(ValueError, match="min_size"):
+        TilingSource(min_size=0)
+
+
+def test_tiling_raises_when_count_unreachable() -> None:
+    source = TilingSource(
+        num_allocations=100, capacity=1024, min_size=1024, makespan=10, min_duration=5
+    )
+    with pytest.raises(ValueError, match="cannot reach"):
+        source.get_allocations()
+
+
+def test_tiling_ground_truth_is_valid_and_optimal() -> None:
+    capacity = 1024 * 1024
+    source = TilingSource(num_allocations=200, capacity=capacity)
+    pool = source.get_ground_truth_pool()
+
+    validate_allocation(pool)
+    assert pool.is_allocated
+    assert pool.size == capacity
+    assert pool.pressure == capacity
+
+
+def test_tiling_ground_truth_matches_get_allocations() -> None:
+    source = TilingSource(num_allocations=64)
+    truth = source.get_ground_truth_pool()
+    allocs = source.get_allocations()
+    assert _signatures(truth.allocations) == _signatures(allocs)
+
+
+def test_tiling_ground_truth_available_per_pool() -> None:
+    source = TilingSource(num_allocations=32)
+    pools = source.get_pools(num_pools=2)
+    truth = source.get_ground_truth_pool(skip=32)
+    assert _signatures(truth.allocations) == _signatures(pools[1].allocations)
+
+
+def test_tiling_ground_truth_requires_seed() -> None:
+    with pytest.raises(ValueError, match="seed"):
+        TilingSource(seed=None).get_ground_truth_pool()
+
+
+def test_tiling_variant_sweep_builds_ladder() -> None:
+    source = TilingSource(capacity=1024 * 1024)
+    for num in (64, 128, 256):
+        pool = source.get_variant(num)
+        assert len(pool.allocations) == num
+        assert pool.pressure == 1024 * 1024
+
+
+def test_tiling_no_allocator_beats_the_optimum() -> None:
+    capacity = 1024 * 1024
+    source = TilingSource(num_allocations=150, capacity=capacity)
+    pool = source.get_pool()
+    allocated = run_allocation(pool, "greedy_by_size_allocator_cpp", validate=True)
+    assert allocated.size >= capacity

--- a/tests/unit/common/test_registry.py
+++ b/tests/unit/common/test_registry.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from abc import abstractmethod
+
 import pytest
 from omnimalloc.allocators import (
     BaseAllocator,
@@ -88,6 +90,20 @@ def test_name_with_numbers() -> None:
         pass
 
     assert Test123Thing.name() == "test123_thing"
+
+
+def test_abstract_intermediate_not_registered() -> None:
+    class AbstractMid(ExampleBase):
+        @abstractmethod
+        def compute(self) -> int: ...
+
+    class ConcreteLeaf(AbstractMid):
+        def compute(self) -> int:
+            return 0
+
+    registry = ExampleBase.registry()
+    assert "abstract_mid" not in registry
+    assert "concrete_leaf" in registry
 
 
 def test_allocator_registry() -> None:


### PR DESCRIPTION
## Summary

Adds two reverse-constructed benchmark sources with a **known, tight optimum**, sharing a common `TilingBase`.

`TilingBase` recursively splits a `capacity x makespan` rectangle into leaf tiles until `num_allocations` is reached; each leaf becomes one allocation (temporal extent = time span, size = memory height). Because the leaves perfectly tile the rectangle, peak pressure equals `capacity` exactly — a provably achievable lower bound, so the optimum is known by construction.

- **`TilingSource`** — recursive **guillotine** cuts (edge-to-edge). `mem_cut_prob` biases cuts toward the memory axis to tune temporal contention/hardness. The optimum is always recoverable by divide-and-conquer.
- **`PinwheelSource`** — the adversarial, **non-guillotine** sibling. Each split becomes a pinwheel (central rectangle ringed by four blades in 90° rotational symmetry), so no straight line crosses the rectangle without slicing a blade and there is no clean time split. Defeats decomposition / canonical-guillotine shortcuts, forcing allocators to actually search. Sweeping `num_allocations` yields a graded difficulty ladder.

Both are registered in `sources/__init__.py`.

## Test plan

- `tests/unit/benchmark/sources/test_tiling.py`
- `tests/unit/benchmark/sources/test_pinwheel.py`