### PR TITLE
Fix StopIteration in hill climb allocator on rejected steps

### DIFF
--- a/src/python/omnimalloc/allocators/hillclimb.py
+++ b/src/python/omnimalloc/allocators/hillclimb.py
@@ -163,9 +163,10 @@ class HillClimbAllocator(BaseAllocator):
         best_memory = self._calculate_total_memory(result)
         best_result = result
 
-        for iteration in range(self.max_iterations):
-            rollback_pos_map = pos_map.copy()
+        # Track the last swap so a rejected step can be undone
+        last_swap: tuple[int, int] | None = None
 
+        for iteration in range(self.max_iterations):
             result = self._greedy_allocate(alloc_list)
             current_memory = self._calculate_total_memory(result)
 
@@ -173,17 +174,19 @@ class HillClimbAllocator(BaseAllocator):
             if self._should_accept(current_memory, best_memory, iteration, rng):
                 best_result = result
                 best_memory = current_memory
-            elif iteration > 0:
-                # Undo last swap
-                swap_idx1 = next(
-                    i for i, a in enumerate(alloc_list) if pos_map[a.id] != i
-                )
-                swap_idx2 = pos_map[alloc_list[swap_idx1].id]
+            elif last_swap is not None:
+                # Undo last swap and re-run greedy on the reverted ordering
+                swap_idx1, swap_idx2 = last_swap
                 alloc_list[swap_idx1], alloc_list[swap_idx2] = (
                     alloc_list[swap_idx2],
                     alloc_list[swap_idx1],
                 )
-                pos_map = rollback_pos_map
+                pos_map[alloc_list[swap_idx1].id] = swap_idx1
+                pos_map[alloc_list[swap_idx2].id] = swap_idx2
+                result = self._greedy_allocate(alloc_list)
+                current_memory = self._calculate_total_memory(result)
+
+            last_swap = None
 
             # Find allocations at maximum memory and select target
             max_allocs = self._find_max_memory_allocations(result, current_memory)
@@ -211,5 +214,6 @@ class HillClimbAllocator(BaseAllocator):
             )
             pos_map[alloc_list[swap_idx1].id] = swap_idx1
             pos_map[alloc_list[swap_idx2].id] = swap_idx2
+            last_swap = (swap_idx1, swap_idx2)
 
         return best_result

--- a/tests/integration/test_allocators_on_sources.py
+++ b/tests/integration/test_allocators_on_sources.py
@@ -13,6 +13,7 @@ from omnimalloc.allocators.greedy import (
     GreedyByDurationAllocator,
     GreedyBySizeAllocator,
 )
+from omnimalloc.allocators.hillclimb import HillClimbAllocator
 from omnimalloc.benchmark.sources.generator import (
     HighContentionSource,
     PowerOf2Source,
@@ -176,6 +177,30 @@ def test_greedy_deterministic_across_runs() -> None:
     offsets1 = [a.offset for a in result1.allocations]
     offsets2 = [a.offset for a in result2.allocations]
     assert offsets1 == offsets2
+
+
+def test_hill_climb_with_high_contention() -> None:
+    source = HighContentionSource(num_allocations=40, time_window=10, seed=42)
+    allocations = source.get_allocations()
+    pool = Pool(id="test_pool", allocations=allocations)
+
+    allocator = HillClimbAllocator(max_iterations=200)
+    allocated_pool = run_allocation(pool, allocator)
+
+    assert validate_allocation(allocated_pool)
+    assert all(a.offset is not None for a in allocated_pool.allocations)
+
+
+def test_hill_climb_with_random_source() -> None:
+    source = RandomSource(num_allocations=50, seed=42)
+    allocations = source.get_allocations()
+    pool = Pool(id="test_pool", allocations=allocations)
+
+    allocator = HillClimbAllocator()
+    allocated_pool = run_allocation(pool, allocator)
+
+    assert validate_allocation(allocated_pool)
+    assert len(allocated_pool.allocations) == 50
 
 
 def test_greedy_with_sequential_produces_small_footprint() -> None:

--- a/tests/unit/allocators/test_hillclimb.py
+++ b/tests/unit/allocators/test_hillclimb.py
@@ -1,0 +1,103 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+from omnimalloc.allocators.hillclimb import HillClimbAllocator
+from omnimalloc.primitives import Allocation
+from omnimalloc.primitives.pool import Pool
+from omnimalloc.validate import validate_allocation
+
+
+def _is_valid(result: tuple[Allocation, ...]) -> bool:
+    return validate_allocation(Pool(id="test_pool", allocations=result))
+
+
+def test_hillclimb_empty() -> None:
+    allocator = HillClimbAllocator()
+    result = allocator.allocate(())
+    assert len(result) == 0
+
+
+def test_hillclimb_single() -> None:
+    allocator = HillClimbAllocator()
+    alloc = Allocation(id=1, size=100, start=0, end=10)
+    result = allocator.allocate((alloc,))
+    assert len(result) == 1
+    assert result[0].offset == 0
+
+
+def test_hillclimb_rejects_positive_iterations() -> None:
+    with pytest.raises(ValueError, match="max_iterations must be positive"):
+        HillClimbAllocator(max_iterations=0)
+
+
+def test_hillclimb_rejects_negative_temperature() -> None:
+    with pytest.raises(ValueError, match="acceptance_temperature must be non-negative"):
+        HillClimbAllocator(acceptance_temperature=-1.0)
+
+
+def test_hillclimb_preserves_allocations() -> None:
+    allocator = HillClimbAllocator()
+    allocs = (
+        Allocation(id=1, size=100, start=0, end=10),
+        Allocation(id=2, size=50, start=5, end=15),
+    )
+    result = allocator.allocate(allocs)
+    assert len(result) == len(allocs)
+    assert {a.id for a in result} == {1, 2}
+    assert all(a.offset is not None for a in result)
+
+
+def test_hillclimb_produces_valid_allocation() -> None:
+    allocator = HillClimbAllocator()
+    allocs = (
+        Allocation(id=1, size=100, start=0, end=5),
+        Allocation(id=2, size=100, start=3, end=8),
+        Allocation(id=3, size=100, start=6, end=10),
+        Allocation(id=4, size=50, start=0, end=10),
+    )
+    result = allocator.allocate(allocs)
+    assert _is_valid(result)
+
+
+def test_hillclimb_no_temporal_overlap_shares_offset() -> None:
+    allocator = HillClimbAllocator()
+    alloc1 = Allocation(id=1, size=100, start=0, end=10)
+    alloc2 = Allocation(id=2, size=200, start=10, end=20)
+    result = allocator.allocate((alloc1, alloc2))
+    by_id = {a.id: a for a in result}
+    assert by_id[1].offset == 0
+    assert by_id[2].offset == 0
+
+
+def test_hillclimb_all_overlap_stacks_sequentially() -> None:
+    allocator = HillClimbAllocator()
+    allocs = tuple(Allocation(id=i, size=100, start=0, end=10) for i in range(5))
+    result = allocator.allocate(allocs)
+    assert _is_valid(result)
+    assert max(a.height for a in result if a.height is not None) == 500
+
+
+def test_hillclimb_survives_rejected_step_undo() -> None:
+    allocator = HillClimbAllocator(max_iterations=6)
+    allocs = (
+        Allocation(id=0, size=50, start=4, end=7),
+        Allocation(id=1, size=40, start=2, end=6),
+        Allocation(id=2, size=30, start=2, end=4),
+        Allocation(id=3, size=40, start=4, end=5),
+        Allocation(id=4, size=70, start=2, end=3),
+    )
+    result = allocator.allocate(allocs)
+    assert len(result) == len(allocs)
+    assert _is_valid(result)
+
+
+def test_hillclimb_deterministic() -> None:
+    allocs = tuple(
+        Allocation(id=i, size=(i % 5 + 1) * 100, start=i % 3, end=i % 3 + i % 7 + 1)
+        for i in range(20)
+    )
+    result1 = HillClimbAllocator(max_iterations=50).allocate(allocs)
+    result2 = HillClimbAllocator(max_iterations=50).allocate(allocs)
+    assert all(r1.offset == r2.offset for r1, r2 in zip(result1, result2, strict=True))


### PR DESCRIPTION
## Summary
Fixes a `StopIteration` crash in the hill climb allocator that aborted allocation whenever simulated annealing rejected a step.

- **Root cause** (`src/python/omnimalloc/allocators/hillclimb.py`) — the undo path found the swap to revert via `next(...)` with no default, but `pos_map` is always in sync with `alloc_list`, so the generator was empty on any rejected step and raised `StopIteration`.
- **Fix** — track the last swap explicitly and revert exactly those indices, keeping `pos_map` consistent and re-running greedy on the reverted ordering. Preserves accepted-solution semantics, API, and determinism.

## Test plan
- `tests/unit/allocators/test_hillclimb.py` — new unit suite; `test_hillclimb_survives_rejected_step_undo` is a minimal deterministic reproducer (red pre-fix, green post-fix).
- `tests/integration/test_allocators_on_sources.py` — adds `test_hill_climb_with_high_contention` (reproduces the crash) and `test_hill_climb_with_random_source`.