### PR TITLE
Add conflict-size and start-order greedy heuristics

### DIFF
--- a/src/python/omnimalloc/allocators/__init__.py
+++ b/src/python/omnimalloc/allocators/__init__.py
@@ -8,14 +8,20 @@ from .greedy import GreedyAllocator as GreedyAllocator
 from .greedy import GreedyByAllAllocator as GreedyByAllAllocator
 from .greedy import GreedyByAreaAllocator as GreedyByAreaAllocator
 from .greedy import GreedyByConflictAllocator as GreedyByConflictAllocator
+from .greedy import GreedyByConflictSizeAllocator as GreedyByConflictSizeAllocator
 from .greedy import GreedyByDurationAllocator as GreedyByDurationAllocator
 from .greedy import GreedyBySizeAllocator as GreedyBySizeAllocator
+from .greedy import GreedyByStartAllocator as GreedyByStartAllocator
 from .greedy_cpp import GreedyAllocatorCpp as GreedyAllocatorCpp
 from .greedy_cpp import GreedyByAllAllocatorCpp as GreedyByAllAllocatorCpp
 from .greedy_cpp import GreedyByAreaAllocatorCpp as GreedyByAreaAllocatorCpp
 from .greedy_cpp import GreedyByConflictAllocatorCpp as GreedyByConflictAllocatorCpp
+from .greedy_cpp import (
+    GreedyByConflictSizeAllocatorCpp as GreedyByConflictSizeAllocatorCpp,
+)
 from .greedy_cpp import GreedyByDurationAllocatorCpp as GreedyByDurationAllocatorCpp
 from .greedy_cpp import GreedyBySizeAllocatorCpp as GreedyBySizeAllocatorCpp
+from .greedy_cpp import GreedyByStartAllocatorCpp as GreedyByStartAllocatorCpp
 from .hillclimb import HillClimbAllocator as HillClimbAllocator
 from .minimalloc import MinimallocAllocator as MinimallocAllocator
 from .naive import NaiveAllocator as NaiveAllocator

--- a/src/python/omnimalloc/allocators/greedy.py
+++ b/src/python/omnimalloc/allocators/greedy.py
@@ -47,22 +47,49 @@ class GreedyByDurationAllocator(GreedyAllocator):
         return super().allocate(tuple(sorted_allocs))
 
 
+def compute_conflict_degrees(
+    allocations: tuple[Allocation, ...],
+) -> dict[Allocation, int]:
+    """Count temporally overlapping allocations for each allocation."""
+    return {
+        alloc: sum(
+            1
+            for other in allocations
+            if other != alloc and alloc.overlaps_temporally(other)
+        )
+        for alloc in allocations
+    }
+
+
 class GreedyByConflictAllocator(GreedyAllocator):
     """Greedy allocator sorting by conflict degree (most conflicted first)."""
 
     def allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
-        conflict_degrees = {}
-        for alloc in allocations:
-            conflicts = sum(
-                1
-                for other in allocations
-                if other != alloc and alloc.overlaps_temporally(other)
-            )
-            conflict_degrees[alloc] = conflicts
-
+        conflict_degrees = compute_conflict_degrees(allocations)
         sorted_allocs = sorted(
             allocations, key=lambda a: (conflict_degrees[a], a.size), reverse=True
         )
+        return super().allocate(tuple(sorted_allocs))
+
+
+class GreedyByConflictSizeAllocator(GreedyAllocator):
+    """Greedy allocator sorting by conflict degree times size (largest first)."""
+
+    def allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
+        conflict_degrees = compute_conflict_degrees(allocations)
+        sorted_allocs = sorted(
+            allocations,
+            key=lambda a: (conflict_degrees[a] * a.size, a.size),
+            reverse=True,
+        )
+        return super().allocate(tuple(sorted_allocs))
+
+
+class GreedyByStartAllocator(GreedyAllocator):
+    """Greedy allocator sorting by start time (earliest first, largest ties first)."""
+
+    def allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
+        sorted_allocs = sorted(allocations, key=lambda a: (a.start, -a.size))
         return super().allocate(tuple(sorted_allocs))
 
 
@@ -117,5 +144,7 @@ class GreedyByAllAllocator(GreedyAllocator):
             GreedyByDurationAllocator(),
             GreedyByAreaAllocator(),
             GreedyByConflictAllocator(),
+            GreedyByConflictSizeAllocator(),
+            GreedyByStartAllocator(),
         )
         return allocate_best_of(variants, allocations)

--- a/src/python/omnimalloc/allocators/greedy_cpp.py
+++ b/src/python/omnimalloc/allocators/greedy_cpp.py
@@ -6,7 +6,7 @@ from omnimalloc._cpp import GreedyAllocatorCpp as _GreedyAllocatorCpp
 from omnimalloc.primitives import Allocation
 
 from .base import BaseAllocator
-from .greedy import allocate_best_of
+from .greedy import allocate_best_of, compute_conflict_degrees
 
 
 class GreedyAllocatorCpp(BaseAllocator):
@@ -33,18 +33,31 @@ class GreedyByConflictAllocatorCpp(GreedyAllocatorCpp):
     """C++ greedy allocator sorting by conflict degree (most conflicted first)."""
 
     def allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
-        conflict_degrees = {}
-        for alloc in allocations:
-            conflicts = sum(
-                1
-                for other in allocations
-                if other != alloc and alloc.overlaps_temporally(other)
-            )
-            conflict_degrees[alloc] = conflicts
-
+        conflict_degrees = compute_conflict_degrees(allocations)
         sorted_allocs = sorted(
             allocations, key=lambda a: (conflict_degrees[a], a.size), reverse=True
         )
+        return super().allocate(tuple(sorted_allocs))
+
+
+class GreedyByConflictSizeAllocatorCpp(GreedyAllocatorCpp):
+    """C++ greedy allocator sorting by conflict degree times size (largest first)."""
+
+    def allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
+        conflict_degrees = compute_conflict_degrees(allocations)
+        sorted_allocs = sorted(
+            allocations,
+            key=lambda a: (conflict_degrees[a] * a.size, a.size),
+            reverse=True,
+        )
+        return super().allocate(tuple(sorted_allocs))
+
+
+class GreedyByStartAllocatorCpp(GreedyAllocatorCpp):
+    """C++ greedy allocator sorting by start time (earliest, largest ties first)."""
+
+    def allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
+        sorted_allocs = sorted(allocations, key=lambda a: (a.start, -a.size))
         return super().allocate(tuple(sorted_allocs))
 
 
@@ -76,5 +89,7 @@ class GreedyByAllAllocatorCpp(GreedyAllocatorCpp):
             GreedyByDurationAllocatorCpp(),
             GreedyByAreaAllocatorCpp(),
             GreedyByConflictAllocatorCpp(),
+            GreedyByConflictSizeAllocatorCpp(),
+            GreedyByStartAllocatorCpp(),
         )
         return allocate_best_of(variants, allocations)

--- a/tests/unit/allocators/test_greedy.py
+++ b/tests/unit/allocators/test_greedy.py
@@ -7,8 +7,10 @@ from omnimalloc.allocators.greedy import (
     GreedyByAllAllocator,
     GreedyByAreaAllocator,
     GreedyByConflictAllocator,
+    GreedyByConflictSizeAllocator,
     GreedyByDurationAllocator,
     GreedyBySizeAllocator,
+    GreedyByStartAllocator,
 )
 from omnimalloc.primitives import Allocation
 
@@ -205,6 +207,66 @@ def test_greedy_by_size_allocates_correctly() -> None:
     assert result[1].offset == 200
 
 
+def test_greedy_by_conflict_size_empty() -> None:
+    allocator = GreedyByConflictSizeAllocator()
+    result = allocator.allocate(())
+    assert len(result) == 0
+
+
+def test_greedy_by_conflict_size_sorts_by_product() -> None:
+    allocator = GreedyByConflictSizeAllocator()
+    big_lonely = Allocation(id=1, size=1000, start=0, end=5)
+    busy_large = Allocation(id=2, size=100, start=10, end=20)
+    busy_medium = Allocation(id=3, size=50, start=10, end=20)
+    busy_small = Allocation(id=4, size=20, start=10, end=20)
+    result = allocator.allocate((big_lonely, busy_large, busy_medium, busy_small))
+    assert [a.id for a in result] == [2, 3, 4, 1]
+
+
+def test_greedy_by_conflict_size_uses_size_as_tiebreaker() -> None:
+    allocator = GreedyByConflictSizeAllocator()
+    small = Allocation(id=1, size=50, start=0, end=10)
+    large = Allocation(id=2, size=200, start=20, end=30)
+    result = allocator.allocate((small, large))
+    assert result[0].id == 2
+    assert result[1].id == 1
+
+
+def test_greedy_by_start_empty() -> None:
+    allocator = GreedyByStartAllocator()
+    result = allocator.allocate(())
+    assert len(result) == 0
+
+
+def test_greedy_by_start_sorts_by_start() -> None:
+    allocator = GreedyByStartAllocator()
+    late = Allocation(id=1, size=100, start=20, end=30)
+    early = Allocation(id=2, size=100, start=0, end=10)
+    middle = Allocation(id=3, size=100, start=10, end=20)
+    result = allocator.allocate((late, early, middle))
+    assert [a.id for a in result] == [2, 3, 1]
+
+
+def test_greedy_by_start_uses_size_as_tiebreaker() -> None:
+    allocator = GreedyByStartAllocator()
+    small = Allocation(id=1, size=50, start=0, end=10)
+    large = Allocation(id=2, size=200, start=0, end=10)
+    result = allocator.allocate((small, large))
+    assert result[0].id == 2
+    assert result[1].id == 1
+
+
+def test_greedy_by_start_allocates_correctly() -> None:
+    allocator = GreedyByStartAllocator()
+    later = Allocation(id=1, size=50, start=5, end=15)
+    earlier = Allocation(id=2, size=100, start=0, end=10)
+    result = allocator.allocate((later, earlier))
+    assert result[0].id == 2
+    assert result[1].id == 1
+    assert result[0].offset == 0
+    assert result[1].offset == 100
+
+
 def test_greedy_allocator_all_overlap() -> None:
     allocator = GreedyAllocator()
     allocs = tuple(Allocation(id=i, size=100, start=0, end=10) for i in range(5))
@@ -293,6 +355,8 @@ def test_greedy_by_all_picks_best_peak() -> None:
         GreedyByDurationAllocator(),
         GreedyByAreaAllocator(),
         GreedyByConflictAllocator(),
+        GreedyByConflictSizeAllocator(),
+        GreedyByStartAllocator(),
     )
     best_variant_peak = min(
         max(a.height for a in v.allocate(allocs) if a.height is not None)

--- a/tests/unit/allocators/test_greedy_cpp.py
+++ b/tests/unit/allocators/test_greedy_cpp.py
@@ -8,8 +8,10 @@ from omnimalloc.allocators.greedy_cpp import (
     GreedyByAllAllocatorCpp,
     GreedyByAreaAllocatorCpp,
     GreedyByConflictAllocatorCpp,
+    GreedyByConflictSizeAllocatorCpp,
     GreedyByDurationAllocatorCpp,
     GreedyBySizeAllocatorCpp,
+    GreedyByStartAllocatorCpp,
 )
 from omnimalloc.primitives import Allocation
 
@@ -204,6 +206,37 @@ def test_greedy_cpp_by_size_allocates_correctly() -> None:
     assert result[1].id == 1
     assert result[0].offset == 0
     assert result[1].offset == 200
+
+
+def test_greedy_cpp_by_conflict_size_empty() -> None:
+    allocator = GreedyByConflictSizeAllocatorCpp()
+    result = allocator.allocate(())
+    assert len(result) == 0
+
+
+def test_greedy_cpp_by_conflict_size_sorts_by_product() -> None:
+    allocator = GreedyByConflictSizeAllocatorCpp()
+    big_lonely = Allocation(id=1, size=1000, start=0, end=5)
+    busy_large = Allocation(id=2, size=100, start=10, end=20)
+    busy_medium = Allocation(id=3, size=50, start=10, end=20)
+    busy_small = Allocation(id=4, size=20, start=10, end=20)
+    result = allocator.allocate((big_lonely, busy_large, busy_medium, busy_small))
+    assert [a.id for a in result] == [2, 3, 4, 1]
+
+
+def test_greedy_cpp_by_start_empty() -> None:
+    allocator = GreedyByStartAllocatorCpp()
+    result = allocator.allocate(())
+    assert len(result) == 0
+
+
+def test_greedy_cpp_by_start_sorts_by_start() -> None:
+    allocator = GreedyByStartAllocatorCpp()
+    late = Allocation(id=1, size=100, start=20, end=30)
+    early = Allocation(id=2, size=100, start=0, end=10)
+    middle = Allocation(id=3, size=100, start=10, end=20)
+    result = allocator.allocate((late, early, middle))
+    assert [a.id for a in result] == [2, 3, 1]
 
 
 def test_greedy_cpp_allocator_all_overlap() -> None:


### PR DESCRIPTION
## Summary

Adds two new greedy sort-order heuristics, selected from 11 candidates benchmarked on minimalloc (challenging + small), tiling, pinwheel, and RandomSource workloads:

- **`GreedyByConflictSizeAllocator[Cpp]`** — sorts by conflict degree × size (size tie-break). Best solo variant overall: weighting large buffers by how contested their time window is beats plain size-sort on minimalloc and random workloads.
- **`GreedyByStartAllocator[Cpp]`** — sorts by start time ascending, size descending on ties. Mediocre alone but a strong ensemble complement: near-optimal on the minimalloc `small` set (solo gap 1.099 vs 1.326 for the previous best-of-5).

Both variants join the Python and C++ `GreedyByAll` ensembles. The conflict-count loop previously duplicated between `greedy.py` and `greedy_cpp.py` is now a shared `compute_conflict_degrees()` helper.

## Results

Gap = peak memory / max-load lower bound, mean over 46 held-out instances (minimalloc challenging A–K + small, tiling/pinwheel at 100–1024 allocations × unseen seeds, RandomSource at 100–1000 allocations × 3 seeds):

| ensemble | mean gap |
|---|---|
| best-of-5 (before) | 1.205 |
| best-of-7 (after) | **1.146** |

Biggest family win: minimalloc `small` 1.326 → 1.041. Verified end-to-end that the shipped Python and C++ by-all allocators both reproduce the 1.146 figure.

Ideas evaluated and rejected: best-fit placement (loses to first-fit everywhere, confirming the comment in `greedy.py`), a max-concurrent-load "pressure" order (good solo, <0.001 ensemble gain), tie-break refinements, and random shuffles. Leave-one-out also shows `area` and `conflict` now contribute zero marginal value to the ensemble on these sets — left untouched as public API, but they are candidates for retirement.

## Testing

- `ruff check`, `ruff format`, `ty check` clean
- 613 unit + 23 integration tests pass (new tests for both variants in `test_greedy.py` / `test_greedy_cpp.py`; by-all best-peak test extended to the 7-variant set)