### PR TITLE
Make conflict degree computation O(n log n)

### DIFF
--- a/src/python/omnimalloc/allocators/greedy.py
+++ b/src/python/omnimalloc/allocators/greedy.py
@@ -3,6 +3,7 @@
 #
 
 import sys
+from bisect import bisect_left, bisect_right
 
 from omnimalloc.primitives import Allocation
 
@@ -51,12 +52,12 @@ def compute_conflict_degrees(
     allocations: tuple[Allocation, ...],
 ) -> dict[Allocation, int]:
     """Count temporally overlapping allocations for each allocation."""
+    starts = sorted(alloc.start for alloc in allocations)
+    ends = sorted(alloc.end for alloc in allocations)
+    # An allocation overlaps [start, end) iff it starts before `end` and does
+    # not end by `start`; subtract 1 so the allocation does not count itself.
     return {
-        alloc: sum(
-            1
-            for other in allocations
-            if other != alloc and alloc.overlaps_temporally(other)
-        )
+        alloc: bisect_left(starts, alloc.end) - bisect_right(ends, alloc.start) - 1
         for alloc in allocations
     }
 

--- a/tests/unit/allocators/test_greedy.py
+++ b/tests/unit/allocators/test_greedy.py
@@ -11,6 +11,7 @@ from omnimalloc.allocators.greedy import (
     GreedyByDurationAllocator,
     GreedyBySizeAllocator,
     GreedyByStartAllocator,
+    compute_conflict_degrees,
 )
 from omnimalloc.primitives import Allocation
 
@@ -116,6 +117,41 @@ def test_greedy_by_duration_allocates_correctly() -> None:
     result = allocator.allocate((short, long))
     assert result[0].offset == 0
     assert result[1].offset == 100
+
+
+def test_compute_conflict_degrees_empty() -> None:
+    assert compute_conflict_degrees(()) == {}
+
+
+def test_compute_conflict_degrees_counts_overlaps() -> None:
+    alone = Allocation(id=1, size=10, start=0, end=5)
+    pair_a = Allocation(id=2, size=10, start=10, end=20)
+    pair_b = Allocation(id=3, size=10, start=15, end=25)
+    degrees = compute_conflict_degrees((alone, pair_a, pair_b))
+    assert degrees[alone] == 0
+    assert degrees[pair_a] == 1
+    assert degrees[pair_b] == 1
+
+
+def test_compute_conflict_degrees_touching_intervals_do_not_conflict() -> None:
+    first = Allocation(id=1, size=10, start=0, end=10)
+    second = Allocation(id=2, size=10, start=10, end=20)
+    degrees = compute_conflict_degrees((first, second))
+    assert degrees[first] == 0
+    assert degrees[second] == 0
+
+
+def test_compute_conflict_degrees_matches_bruteforce() -> None:
+    allocs = tuple(
+        Allocation(id=i, size=i + 1, start=(i * 7) % 23, end=(i * 7) % 23 + i % 6 + 1)
+        for i in range(50)
+    )
+    degrees = compute_conflict_degrees(allocs)
+    for alloc in allocs:
+        expected = sum(
+            1 for other in allocs if other != alloc and alloc.overlaps_temporally(other)
+        )
+        assert degrees[alloc] == expected
 
 
 def test_greedy_by_conflict_empty() -> None:


### PR DESCRIPTION
## Summary

`compute_conflict_degrees()` was an all-pairs Python loop — O(n²) `overlaps_temporally` calls — and profiling showed it dominates the by-all ensembles at scale (83% of `greedy_by_all_cpp` wall time at n=10k, since two variants each recompute it).

This PR replaces it with two `bisect` lookups over pre-sorted start/end lists:

```
degree(a) = #{starts < a.end} − #{ends ≤ a.start} − 1
```

Any allocation starting before `a.end` either overlaps `a` or has already ended by `a.start` (intervals are half-open, and `start < end` is validated on construction); the −1 removes `a` itself. Same result, O(n log n).

## Results

| workload | before | after |
|---|---|---|
| `greedy_by_conflict_cpp`, rand n=10k | 5.7s | **0.52s** |
| `greedy_by_all_cpp`, rand n=10k | 14.3s | **3.6s** |
| `greedy_by_all_cpp`, rand n=1000 | 0.14s | **0.044s** |

Allocation peaks are byte-identical across the benchmark suites (minimalloc, tiling, pinwheel, random).

## Testing

- New unit tests: empty input, overlap counting, half-open touching intervals, and a 50-allocation brute-force equivalence check against the old O(n²) definition
- `ruff`, `ty`, and the allocator test suite pass (86 tests)

Note: equivalence to the old `other != alloc` exclusion holds for valid inputs (unique ids, which `validate_allocation` enforces); for pathological inputs containing fully identical duplicate allocations the old version excluded twins from the count while the new one counts them.