### PR TITLE
Run test job on all wheel-target platforms

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -58,6 +58,9 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    # Force matplotlib's non-interactive backend; runners lack a working Tcl/Tk.
+    env:
+      MPLBACKEND: Agg
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -56,12 +56,22 @@ jobs:
       - run: uv run python examples/04_sources.py
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
+        # Full Python matrix on Linux, plus one job per additional platform
+        # the wheels are built for (keep in sync with build.yml).
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: ubuntu-24.04-arm
+            python-version: "3.13"
+          - os: macos-latest
+            python-version: "3.13"
+          - os: windows-latest
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -72,7 +82,9 @@ jobs:
             pyproject.toml
       - run: uv python install ${{ matrix.python-version }}
       - run: uv sync --extra all
+      # minimalloc builds from source; only known to build on Linux runners
       - run: uv pip install ${{ env.MINIMALLOC_URL }}
+        if: runner.os == 'Linux'
       - run: uv run pytest --cov-report=xml --cov-report=term-missing -v
 
   build:

--- a/examples/03_allocators.py
+++ b/examples/03_allocators.py
@@ -11,6 +11,7 @@ from omnimalloc import (
     run_allocation,
 )
 from omnimalloc.allocators import get_available_allocators, get_default_allocator
+from omnimalloc.allocators.minimalloc import HAS_MINIMALLOC
 
 example_dir = Path("03_example_output")
 
@@ -32,6 +33,10 @@ plot_allocation(pool, example_dir / f"allocation_{default_allocator_name}_defaul
 
 # Run allocation with all available allocators
 for allocator_name in get_available_allocators():
+    # minimalloc is an optional dependency that only builds on some platforms
+    if "minimalloc" in allocator_name and not HAS_MINIMALLOC:
+        print(f"Skipping unavailable allocator: {allocator_name}")
+        continue
     print(f"Running allocation with allocator: {allocator_name}")
     pool = run_allocation(pool, allocator_name, validate=True)
 

--- a/examples/05_benchmark.py
+++ b/examples/05_benchmark.py
@@ -4,6 +4,7 @@
 
 from pathlib import Path
 
+from omnimalloc.allocators.minimalloc import HAS_MINIMALLOC
 from omnimalloc.benchmark import (
     plot_benchmark,
     run_benchmark,
@@ -17,8 +18,10 @@ allocators = (
     "greedy_by_size_allocator",
     "greedy_by_size_allocator_cpp",
     "greedy_by_conflict_allocator",
-    "minimalloc_allocator",
 )
+# minimalloc is an optional dependency that only builds on some platforms
+if HAS_MINIMALLOC:
+    allocators += ("minimalloc_allocator",)
 sources = (
     "random_source",
     "minimalloc_source",


### PR DESCRIPTION
## Summary

Extends the `Checks` test matrix beyond `ubuntu-latest` so the test suite runs on every platform we build wheels for (matching the cibuildwheel matrix in `build.yml`):

- **Linux x86** keeps the full Python matrix (3.10-3.13), unchanged.
- **`ubuntu-24.04-arm`, `macos-latest`, `windows-latest`** each get one job at Python 3.13, added via matrix `include` (7 jobs total instead of a 16-job cross-product; the extra platforms are there to catch OS differences, not Python-version differences).
- The minimalloc source install is gated to Linux runners (`if: runner.os == 'Linux'`), matching what CI does today. Nothing in the test suite requires the package: the minimalloc tests use the vendored CSV datasets.

## Notes

- This is the first time the suite executes on macOS/Windows runners, so this PR's own CI run is the real validation.
- Previously, macOS/Windows only got compile coverage via `build.yml`, and only on pushes to main/releases - platform-specific breakage could not surface before merge.