### PR TITLE
Extract shared first-fit and local-search helpers, dedup allocator internals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,9 @@ nanobind_add_module(
   NB_STATIC
   NOMINSIZE
   src/cpp/allocators/best_fit.cpp
+  src/cpp/allocators/first_fit.cpp
   src/cpp/allocators/greedy.cpp
-  src/cpp/allocators/greedy_base.cpp
+  src/cpp/allocators/local_search.cpp
   src/cpp/allocators/simulated_annealing.cpp
   src/cpp/allocators/supermalloc/partition.cpp
   src/cpp/allocators/tabu_search.cpp

--- a/src/cpp/allocators/best_fit.cpp
+++ b/src/cpp/allocators/best_fit.cpp
@@ -6,6 +6,8 @@
 
 #include <algorithm>
 
+#include "first_fit.hpp"
+
 namespace omnimalloc {
 
 namespace {
@@ -33,25 +35,12 @@ int64_t find_best_fit_offset(
 
 std::vector<Allocation> BestFitAllocator::allocate(
     const std::vector<Allocation>& allocations) const {
-  check_total_size(allocations);
-  const OverlapIndices indices = compute_overlap_indices(allocations);
-  std::vector<std::optional<int64_t>> offsets(allocations.size());
-  std::vector<std::pair<int64_t, int64_t>> spans;
-  std::vector<Allocation> placed_allocations;
-  placed_allocations.reserve(allocations.size());
-  for (size_t i = 0; i < allocations.size(); ++i) {
-    spans.clear();
-    for (size_t j : indices[i]) {
-      if (offsets[j].has_value()) {
-        spans.emplace_back(*offsets[j], *offsets[j] + allocations[j].size());
-      }
-    }
-    std::sort(spans.begin(), spans.end());
-    offsets[i] = find_best_fit_offset(allocations[i].size(), spans);
-    placed_allocations.push_back(allocations[i].with_offset(*offsets[i]));
-  }
-
-  return placed_allocations;
+  // Lambda rather than the function pointer so the placement loop inlines
+  // the offset scan instead of an indirect call per allocation
+  return place_indexed(allocations, compute_overlap_indices(allocations),
+                       [](int64_t size, const auto& spans) {
+                         return find_best_fit_offset(size, spans);
+                       });
 }
 
 }  // namespace omnimalloc

--- a/src/cpp/allocators/best_fit.hpp
+++ b/src/cpp/allocators/best_fit.hpp
@@ -6,7 +6,6 @@
 
 #include <vector>
 
-#include "greedy_base.hpp"
 #include "primitives/allocation.hpp"
 
 namespace omnimalloc {

--- a/src/cpp/allocators/defaults.hpp
+++ b/src/cpp/allocators/defaults.hpp
@@ -4,10 +4,35 @@
 
 #pragma once
 
+#include <chrono>
+#include <optional>
+
 namespace omnimalloc {
 
 // Shared wall-clock budget for every time-bounded allocator (seconds).
 // Mirrors DEFAULT_TIMEOUT in the Python package.
 inline constexpr double kDefaultTimeout = 3.0;
+
+// Deadline `timeout` seconds from now, or nullopt when `timeout` is not
+// positive (the budget is disabled). The cap keeps the duration cast
+// representable and also absorbs inf and NaN.
+[[nodiscard]] inline std::optional<std::chrono::steady_clock::time_point>
+make_deadline(double timeout) noexcept {
+  if (timeout <= 0.0) {
+    return std::nullopt;
+  }
+  constexpr double kMaxSeconds = 1e9;  // ~31 years
+  const double seconds = timeout < kMaxSeconds ? timeout : kMaxSeconds;
+  return std::chrono::steady_clock::now() +
+         std::chrono::duration_cast<std::chrono::steady_clock::duration>(
+             std::chrono::duration<double>(seconds));
+}
+
+// True when `deadline` is set and has passed.
+[[nodiscard]] inline bool deadline_expired(
+    const std::optional<std::chrono::steady_clock::time_point>&
+        deadline) noexcept {
+  return deadline && std::chrono::steady_clock::now() >= *deadline;
+}
 
 }  // namespace omnimalloc

--- a/src/cpp/allocators/first_fit.cpp
+++ b/src/cpp/allocators/first_fit.cpp
@@ -2,10 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#include "greedy_base.hpp"
+#include "first_fit.hpp"
 
 #include <algorithm>
-#include <numeric>
 #include <stdexcept>
 #include <tuple>
 #include <utility>
@@ -66,49 +65,6 @@ OverlapIndices compute_overlap_indices(
   return indices;
 }
 
-int64_t peak_of(const std::vector<Allocation>& placed) {
-  int64_t peak = 0;
-  for (const auto& alloc : placed) {
-    if (const auto height = alloc.height()) {
-      peak = std::max(peak, *height);
-    }
-  }
-  return peak;
-}
-
-std::vector<size_t> initial_order(const std::vector<Allocation>& allocations) {
-  std::vector<size_t> order(allocations.size());
-  std::iota(order.begin(), order.end(), size_t{0});
-  std::stable_sort(order.begin(), order.end(), [&](size_t a, size_t b) {
-    return allocations[a].size() > allocations[b].size();
-  });
-  return order;
-}
-
-std::vector<size_t> earlier_neighbors(
-    const std::vector<size_t>& order, size_t target_pos,
-    const std::vector<Allocation>& allocations,
-    const TemporalOverlaps& overlaps) {
-  std::vector<size_t> neighbors;
-  auto it = overlaps.find(allocations[order[target_pos]].id());
-  if (it != overlaps.end()) {
-    for (size_t pos = 0; pos < target_pos; ++pos) {
-      if (it->second.count(allocations[order[pos]].id())) {
-        neighbors.push_back(pos);
-      }
-    }
-  }
-  if (neighbors.empty()) {
-    neighbors.resize(target_pos);
-    std::iota(neighbors.begin(), neighbors.end(), size_t{0});
-  }
-  return neighbors;
-}
-
-namespace {
-
-// Occupied (offset, end) spans of the already-placed neighbors of one
-// allocation, sorted by offset so the gap scans can go left-to-right
 void gather_spans(const std::vector<size_t>& neighbors,
                   const std::vector<std::optional<int64_t>>& offsets,
                   const std::vector<Allocation>& allocations,
@@ -122,7 +78,6 @@ void gather_spans(const std::vector<size_t>& neighbors,
   std::sort(spans.begin(), spans.end());
 }
 
-// First-fit: lowest offset where `size` fits between the sorted spans
 int64_t first_fit_offset(
     int64_t size, const std::vector<std::pair<int64_t, int64_t>>& spans) {
   int64_t best_offset = 0;
@@ -135,21 +90,14 @@ int64_t first_fit_offset(
   return best_offset;
 }
 
-}  // namespace
-
 std::vector<Allocation> first_fit_place_indexed(
     const std::vector<Allocation>& allocations, const OverlapIndices& indices) {
-  check_total_size(allocations);
-  std::vector<std::optional<int64_t>> offsets(allocations.size());
-  std::vector<std::pair<int64_t, int64_t>> spans;
-  std::vector<Allocation> placed;
-  placed.reserve(allocations.size());
-  for (size_t i = 0; i < allocations.size(); ++i) {
-    gather_spans(indices[i], offsets, allocations, spans);
-    offsets[i] = first_fit_offset(allocations[i].size(), spans);
-    placed.push_back(allocations[i].with_offset(*offsets[i]));
-  }
-  return placed;
+  // Lambda rather than the function pointer so the placement loop inlines
+  // the offset scan instead of an indirect call per allocation
+  return place_indexed(allocations, indices,
+                       [](int64_t size, const auto& spans) {
+                         return first_fit_offset(size, spans);
+                       });
 }
 
 std::vector<Allocation> first_fit_place(

--- a/src/cpp/allocators/first_fit.hpp
+++ b/src/cpp/allocators/first_fit.hpp
@@ -9,6 +9,7 @@
 #include <optional>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 #include "primitives/allocation.hpp"
@@ -38,6 +39,17 @@ void check_total_size(const std::vector<Allocation>& allocations,
 [[nodiscard]] OverlapIndices compute_overlap_indices(
     const std::vector<Allocation>& allocations);
 
+// Occupied (offset, end) spans of the already-placed neighbors of one
+// allocation, sorted by offset so the gap scans can go left-to-right
+void gather_spans(const std::vector<size_t>& neighbors,
+                  const std::vector<std::optional<int64_t>>& offsets,
+                  const std::vector<Allocation>& allocations,
+                  std::vector<std::pair<int64_t, int64_t>>& spans);
+
+// First-fit: lowest offset where `size` fits between the sorted spans
+[[nodiscard]] int64_t first_fit_offset(
+    int64_t size, const std::vector<std::pair<int64_t, int64_t>>& spans);
+
 // Greedily place allocations in order using first-fit, reusing a precomputed
 // overlap map
 [[nodiscard]] std::vector<Allocation> first_fit_place(
@@ -49,20 +61,25 @@ void check_total_size(const std::vector<Allocation>& allocations,
 [[nodiscard]] std::vector<Allocation> first_fit_place_indexed(
     const std::vector<Allocation>& allocations, const OverlapIndices& indices);
 
-// Peak memory (highest end offset) across the placed allocations
-[[nodiscard]] int64_t peak_of(const std::vector<Allocation>& placed);
-
-// Indices into `allocations`, sorted largest-size-first: a decent, cheap
-// starting order for the order-search allocators.
-[[nodiscard]] std::vector<size_t> initial_order(
-    const std::vector<Allocation>& allocations);
-
-// Positions before `target_pos` in `order` whose allocation temporally
-// overlaps the one at `target_pos`, or every earlier position if none do.
-[[nodiscard]] std::vector<size_t> earlier_neighbors(
-    const std::vector<size_t>& order, size_t target_pos,
-    const std::vector<Allocation>& allocations,
-    const TemporalOverlaps& overlaps);
+// Shared placement skeleton of the first-fit and best-fit placers: place
+// allocations in index order, choosing each offset with `choose_offset` over
+// the sorted spans of the allocation's already-placed neighbors
+template <typename OffsetFn>
+[[nodiscard]] std::vector<Allocation> place_indexed(
+    const std::vector<Allocation>& allocations, const OverlapIndices& indices,
+    OffsetFn choose_offset) {
+  check_total_size(allocations);
+  std::vector<std::optional<int64_t>> offsets(allocations.size());
+  std::vector<std::pair<int64_t, int64_t>> spans;
+  std::vector<Allocation> placed;
+  placed.reserve(allocations.size());
+  for (size_t i = 0; i < allocations.size(); ++i) {
+    gather_spans(indices[i], offsets, allocations, spans);
+    offsets[i] = choose_offset(allocations[i].size(), spans);
+    placed.push_back(allocations[i].with_offset(*offsets[i]));
+  }
+  return placed;
+}
 
 // Resident first-fit placer for the order-search allocators (genetic, random,
 // hill-climb): owns the allocations and their overlap maps (computed once) so

--- a/src/cpp/allocators/greedy.cpp
+++ b/src/cpp/allocators/greedy.cpp
@@ -4,7 +4,7 @@
 
 #include "greedy.hpp"
 
-#include "greedy_base.hpp"
+#include "first_fit.hpp"
 
 namespace omnimalloc {
 

--- a/src/cpp/allocators/local_search.cpp
+++ b/src/cpp/allocators/local_search.cpp
@@ -1,0 +1,78 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "local_search.hpp"
+
+#include <algorithm>
+#include <numeric>
+
+namespace omnimalloc {
+
+int64_t peak_of(const std::vector<Allocation>& placed) {
+  int64_t peak = 0;
+  for (const auto& alloc : placed) {
+    if (const auto height = alloc.height()) {
+      peak = std::max(peak, *height);
+    }
+  }
+  return peak;
+}
+
+std::vector<size_t> peak_positions(const std::vector<Allocation>& placed,
+                                   int64_t peak) {
+  std::vector<size_t> positions;
+  for (size_t pos = 0; pos < placed.size(); ++pos) {
+    const auto height = placed[pos].height();
+    if (height && *height == peak) {
+      positions.push_back(pos);
+    }
+  }
+  return positions;
+}
+
+std::vector<size_t> initial_order(const std::vector<Allocation>& allocations) {
+  std::vector<size_t> order(allocations.size());
+  std::iota(order.begin(), order.end(), size_t{0});
+  std::stable_sort(order.begin(), order.end(), [&](size_t a, size_t b) {
+    return allocations[a].size() > allocations[b].size();
+  });
+  return order;
+}
+
+std::vector<size_t> earlier_neighbors(
+    const std::vector<size_t>& order, size_t target_pos,
+    const std::vector<Allocation>& allocations,
+    const TemporalOverlaps& overlaps) {
+  std::vector<size_t> neighbors;
+  auto it = overlaps.find(allocations[order[target_pos]].id());
+  if (it != overlaps.end()) {
+    for (size_t pos = 0; pos < target_pos; ++pos) {
+      if (it->second.count(allocations[order[pos]].id())) {
+        neighbors.push_back(pos);
+      }
+    }
+  }
+  if (neighbors.empty()) {
+    neighbors.resize(target_pos);
+    std::iota(neighbors.begin(), neighbors.end(), size_t{0});
+  }
+  return neighbors;
+}
+
+std::optional<std::pair<size_t, size_t>> propose_peak_swap(
+    const std::vector<size_t>& peaks, const std::vector<size_t>& order,
+    const std::vector<Allocation>& allocations,
+    const TemporalOverlaps& overlaps, std::mt19937_64& rng) {
+  std::uniform_int_distribution<size_t> pick_peak(0, peaks.size() - 1);
+  const size_t target_pos = peaks[pick_peak(rng)];
+  const std::vector<size_t> neighbors =
+      earlier_neighbors(order, target_pos, allocations, overlaps);
+  if (neighbors.empty()) {
+    return std::nullopt;
+  }
+  std::uniform_int_distribution<size_t> pick_neighbor(0, neighbors.size() - 1);
+  return std::make_pair(target_pos, neighbors[pick_neighbor(rng)]);
+}
+
+}  // namespace omnimalloc

--- a/src/cpp/allocators/local_search.hpp
+++ b/src/cpp/allocators/local_search.hpp
@@ -1,0 +1,46 @@
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <random>
+#include <utility>
+#include <vector>
+
+#include "first_fit.hpp"
+#include "primitives/allocation.hpp"
+
+namespace omnimalloc {
+
+// Peak memory (highest end offset) across the placed allocations
+[[nodiscard]] int64_t peak_of(const std::vector<Allocation>& placed);
+
+// Positions in `placed` whose allocation tops out at `peak`: the move
+// candidates for the peak-lowering local searches.
+[[nodiscard]] std::vector<size_t> peak_positions(
+    const std::vector<Allocation>& placed, int64_t peak);
+
+// Indices into `allocations`, sorted largest-size-first: a decent, cheap
+// starting order for the order-search allocators.
+[[nodiscard]] std::vector<size_t> initial_order(
+    const std::vector<Allocation>& allocations);
+
+// Positions before `target_pos` in `order` whose allocation temporally
+// overlaps the one at `target_pos`, or every earlier position if none do.
+[[nodiscard]] std::vector<size_t> earlier_neighbors(
+    const std::vector<size_t>& order, size_t target_pos,
+    const std::vector<Allocation>& allocations,
+    const TemporalOverlaps& overlaps);
+
+// One random peak-lowering move for the local searches: a random position
+// among `peaks` paired with a random earlier temporal neighbor, or nullopt
+// when the chosen target has no earlier position to swap with.
+[[nodiscard]] std::optional<std::pair<size_t, size_t>> propose_peak_swap(
+    const std::vector<size_t>& peaks, const std::vector<size_t>& order,
+    const std::vector<Allocation>& allocations,
+    const TemporalOverlaps& overlaps, std::mt19937_64& rng);
+
+}  // namespace omnimalloc

--- a/src/cpp/allocators/simulated_annealing.cpp
+++ b/src/cpp/allocators/simulated_annealing.cpp
@@ -4,12 +4,12 @@
 
 #include "simulated_annealing.hpp"
 
-#include <chrono>
 #include <cmath>
 #include <random>
 #include <utility>
 
-#include "greedy_base.hpp"
+#include "first_fit.hpp"
+#include "local_search.hpp"
 
 namespace omnimalloc {
 
@@ -34,37 +34,26 @@ std::vector<Allocation> SimulatedAnnealingAllocator::allocate(
   std::uniform_real_distribution<double> unit(0.0, 1.0);
   double temperature = config_.initial_temperature;
 
-  const auto deadline = std::chrono::steady_clock::now() +
-                        std::chrono::duration<double>(config_.timeout);
+  const auto deadline = make_deadline(config_.timeout);
 
   for (int iteration = 0; iteration < config_.max_iterations; ++iteration) {
-    if (config_.timeout > 0.0 && std::chrono::steady_clock::now() >= deadline) {
+    if (deadline_expired(deadline)) {
       break;
     }
 
-    std::vector<size_t> peak_positions;
-    for (size_t pos = 0; pos < current_placed.size(); ++pos) {
-      const auto height = current_placed[pos].height();
-      if (height && *height == current_peak) {
-        peak_positions.push_back(pos);
-      }
-    }
-    if (peak_positions.empty()) {
+    const std::vector<size_t> peaks =
+        peak_positions(current_placed, current_peak);
+    if (peaks.empty()) {
       break;  // no placed allocation reaches the peak: nothing to perturb
     }
 
-    std::uniform_int_distribution<size_t> pick_peak(0,
-                                                    peak_positions.size() - 1);
-    size_t target_pos = peak_positions[pick_peak(rng)];
-    std::vector<size_t> neighbors =
-        earlier_neighbors(order, target_pos, allocations, placer.overlaps());
-    if (neighbors.empty()) {
+    const auto proposal =
+        propose_peak_swap(peaks, order, allocations, placer.overlaps(), rng);
+    if (!proposal) {
       temperature *= config_.cooling_rate;
       continue;
     }
-    std::uniform_int_distribution<size_t> pick_neighbor(0,
-                                                        neighbors.size() - 1);
-    size_t other_pos = neighbors[pick_neighbor(rng)];
+    const auto [target_pos, other_pos] = *proposal;
 
     std::swap(order[target_pos], order[other_pos]);
     std::vector<Allocation> candidate_placed = placer.place(order);

--- a/src/cpp/allocators/supermalloc/partition.cpp
+++ b/src/cpp/allocators/supermalloc/partition.cpp
@@ -18,6 +18,9 @@
 #include <unordered_set>
 #include <utility>
 
+#include "allocators/defaults.hpp"
+#include "allocators/first_fit.hpp"
+
 #if defined(_WIN32)
 #ifndef NOMINMAX
 #define NOMINMAX  // keep <windows.h> from defining min/max macros
@@ -213,13 +216,7 @@ Partition Partition::from_allocations(std::vector<Allocation> allocations) {
   // Every offset, top, and floor + total the search computes is bounded by
   // twice the total size, so rejecting sums above INT64_MAX / 2 rules out
   // signed overflow everywhere downstream.
-  int64_t total_size = 0;
-  for (const Allocation& a : allocations) {
-    if (a.size() > INT64_MAX / 2 - total_size) {
-      throw std::overflow_error("Total allocation size exceeds int64 range");
-    }
-    total_size += a.size();
-  }
+  check_total_size(allocations);
 
   auto data = build_shared_data(std::move(allocations));
 
@@ -940,14 +937,11 @@ void run_workers(const std::function<void()>& work, int num_threads,
   if (error) std::rethrow_exception(error);
 }
 
-// Cap the timeout so the duration cast stays representable; the comparison
-// also absorbs inf and NaN.
+// Unlike the allocators, `greedy_many`/`solve_many` treat a non-positive
+// timeout as an already-expired budget rather than a disabled one, so a
+// missing deadline collapses to "now".
 std::chrono::steady_clock::time_point compute_deadline(double timeout) {
-  constexpr double kMaxSeconds = 1e9;  // ~31 years
-  const double seconds = timeout < kMaxSeconds ? timeout : kMaxSeconds;
-  return std::chrono::steady_clock::now() +
-         std::chrono::duration_cast<std::chrono::steady_clock::duration>(
-             std::chrono::duration<double>(seconds));
+  return make_deadline(timeout).value_or(std::chrono::steady_clock::now());
 }
 
 }  // namespace

--- a/src/cpp/allocators/tabu_search.cpp
+++ b/src/cpp/allocators/tabu_search.cpp
@@ -4,12 +4,12 @@
 
 #include "tabu_search.hpp"
 
-#include <chrono>
 #include <random>
 #include <unordered_map>
 #include <utility>
 
-#include "greedy_base.hpp"
+#include "first_fit.hpp"
+#include "local_search.hpp"
 
 namespace omnimalloc {
 
@@ -47,26 +47,18 @@ std::vector<Allocation> TabuSearchAllocator::allocate(
   std::mt19937_64 rng(config_.seed);
   std::unordered_map<int64_t, int> tabu_until;
 
-  const auto deadline = std::chrono::steady_clock::now() +
-                        std::chrono::duration<double>(config_.timeout);
+  const auto deadline = make_deadline(config_.timeout);
 
   for (int iteration = 0; iteration < config_.max_iterations; ++iteration) {
-    if (config_.timeout > 0.0 && std::chrono::steady_clock::now() >= deadline) {
+    if (deadline_expired(deadline)) {
       break;
     }
 
-    std::vector<size_t> peak_positions;
-    for (size_t pos = 0; pos < current_placed.size(); ++pos) {
-      const auto height = current_placed[pos].height();
-      if (height && *height == current_peak) {
-        peak_positions.push_back(pos);
-      }
-    }
-    if (peak_positions.empty()) {
+    const std::vector<size_t> peaks =
+        peak_positions(current_placed, current_peak);
+    if (peaks.empty()) {
       break;  // no placed allocation reaches the peak: nothing to perturb
     }
-    std::uniform_int_distribution<size_t> pick_peak(0,
-                                                    peak_positions.size() - 1);
 
     // Sample a neighborhood of candidate swaps and keep the best admissible
     // one: non-tabu, or tabu but beating the best-ever solution (aspiration).
@@ -77,15 +69,12 @@ std::vector<Allocation> TabuSearchAllocator::allocate(
     bool best_is_tabu = false;
 
     for (int sample = 0; sample < config_.neighborhood_size; ++sample) {
-      size_t target_pos = peak_positions[pick_peak(rng)];
-      std::vector<size_t> neighbors =
-          earlier_neighbors(order, target_pos, allocations, placer.overlaps());
-      if (neighbors.empty()) {
+      const auto proposal =
+          propose_peak_swap(peaks, order, allocations, placer.overlaps(), rng);
+      if (!proposal) {
         continue;
       }
-      std::uniform_int_distribution<size_t> pick_neighbor(0,
-                                                          neighbors.size() - 1);
-      size_t other_pos = neighbors[pick_neighbor(rng)];
+      const auto [target_pos, other_pos] = *proposal;
 
       auto tabu_it =
           tabu_until.find(tabu_key(order[target_pos], order[other_pos], n));

--- a/src/cpp/allocators/telamalloc.cpp
+++ b/src/cpp/allocators/telamalloc.cpp
@@ -11,10 +11,9 @@
 #include <random>
 #include <set>
 #include <tuple>
-#include <unordered_set>
 #include <utility>
 
-#include "greedy_base.hpp"
+#include "first_fit.hpp"
 
 namespace omnimalloc {
 
@@ -26,40 +25,9 @@ using Deadline = std::optional<Clock::time_point>;
 // Effectively-unbounded capacity: makes a pack attempt plain first-fit.
 constexpr int64_t kUnbounded = std::numeric_limits<int64_t>::max() / 4;
 
-// Index-based temporal adjacency via a sweep over start/end events; ends
-// sort before starts at equal times, so touching [start, end) intervals do
-// not overlap.
-std::vector<std::vector<int>> build_neighbors(
-    const std::vector<Allocation>& allocations) {
-  const int n = static_cast<int>(allocations.size());
-  std::vector<std::tuple<int64_t, bool, int>> events;
-  events.reserve(2 * static_cast<size_t>(n));
-  for (int i = 0; i < n; ++i) {
-    events.emplace_back(allocations[i].start(), true, i);
-    events.emplace_back(allocations[i].end(), false, i);
-  }
-  std::sort(events.begin(), events.end());
-
-  std::vector<std::vector<int>> neighbors(n);
-  std::unordered_set<int> active;
-  for (const auto& [time, is_start, idx] : events) {
-    if (is_start) {
-      for (int other : active) {
-        neighbors[idx].push_back(other);
-        neighbors[other].push_back(idx);
-      }
-      active.insert(idx);
-    } else {
-      active.erase(idx);
-    }
-  }
-  return neighbors;
-}
-
 // Connected components of the overlap graph: the paper's "phases". Buffers
 // in different components never interact, so each packs independently.
-std::vector<std::vector<int>> build_phases(
-    const std::vector<std::vector<int>>& neighbors) {
+std::vector<std::vector<int>> build_phases(const OverlapIndices& neighbors) {
   const int n = static_cast<int>(neighbors.size());
   std::vector<std::vector<int>> phases;
   std::vector<char> visited(n, 0);
@@ -74,10 +42,10 @@ std::vector<std::vector<int>> build_phases(
       int idx = stack.back();
       stack.pop_back();
       phase.push_back(idx);
-      for (int other : neighbors[idx]) {
+      for (size_t other : neighbors[idx]) {
         if (!visited[other]) {
           visited[other] = 1;
-          stack.push_back(other);
+          stack.push_back(static_cast<int>(other));
         }
       }
     }
@@ -131,8 +99,7 @@ QueueKey queue_key(const Allocation& alloc, int idx, int evictions,
 // `capacity` at least the phase's max buffer size guarantees offset 0 is
 // always a repair candidate, so every iteration makes progress.
 std::optional<std::vector<int64_t>> pack_phase(
-    const std::vector<Allocation>& allocations,
-    const std::vector<std::vector<int>>& neighbors,
+    const std::vector<Allocation>& allocations, const OverlapIndices& neighbors,
     const std::vector<int>& phase, int64_t capacity, int max_backtracks,
     const Deadline& deadline, bool size_major, uint64_t seed) {
   std::vector<int64_t> offsets(allocations.size(), -1);
@@ -146,6 +113,10 @@ std::optional<std::vector<int64_t>> pack_phase(
       std::min(max_backtracks, 4 * static_cast<int>(phase.size()));
   int total_backtracks = 0;
 
+  // Scratch buffers for the placement loop, reused across queue pops.
+  std::vector<std::pair<int64_t, int>> occupied;   // (offset, neighbor)
+  std::vector<std::pair<int64_t, int64_t>> spans;  // (offset, end)
+
   while (true) {
     for (int idx : phase) {
       offsets[idx] = -1;
@@ -158,33 +129,33 @@ std::optional<std::vector<int64_t>> pack_phase(
     int restart_backtracks = 0;
 
     while (!pending.empty()) {
-      if (deadline && Clock::now() >= *deadline) {
+      if (deadline_expired(deadline)) {
         return std::nullopt;
       }
       const int idx = std::get<3>(*pending.begin());
       pending.erase(pending.begin());
       const int64_t size = allocations[idx].size();
 
-      // Spatial intervals of the already-placed temporal neighbors.
-      std::vector<std::pair<int64_t, int>> occupied;  // (offset, neighbor)
-      for (int other : neighbors[idx]) {
+      // Spatial intervals of the already-placed temporal neighbors. The
+      // spans inherit occupied's offset order (ties differ only in end
+      // order, which cannot change a gap scan's result), so one sort does.
+      occupied.clear();
+      for (size_t other : neighbors[idx]) {
         if (offsets[other] >= 0) {
-          occupied.emplace_back(offsets[other], other);
+          occupied.emplace_back(offsets[other], static_cast<int>(other));
         }
       }
       std::sort(occupied.begin(), occupied.end());
-
-      // First-fit: lowest gap among the placed neighbors that fits.
-      int64_t cursor = 0;
-      bool in_gap = false;
+      spans.clear();
       for (const auto& [offset, other] : occupied) {
-        if (offset - cursor >= size) {
-          in_gap = true;
-          break;
-        }
-        cursor = std::max(cursor, offset + allocations[other].size());
+        spans.emplace_back(offset, offset + allocations[other].size());
       }
-      if (in_gap || cursor + size <= capacity) {
+
+      // First-fit: lowest gap among the placed neighbors that fits. Every
+      // committed offset satisfies offset + size <= capacity, so a fit below
+      // a committed neighbor's offset passes the capacity check transitively.
+      const int64_t cursor = first_fit_offset(size, spans);
+      if (cursor + size <= capacity) {
         offsets[idx] = cursor;
         continue;
       }
@@ -272,10 +243,9 @@ int64_t phase_peak(const std::vector<Allocation>& allocations,
 // treated as infeasible even though they are only budget-exhausted, keeping
 // the search anytime rather than exact.
 void solve_phase(const std::vector<Allocation>& allocations,
-                 const std::vector<std::vector<int>>& neighbors,
-                 const std::vector<int>& phase, int64_t lower_bound,
-                 const TelamallocConfig& config, const Deadline& deadline,
-                 std::vector<int64_t>& result) {
+                 const OverlapIndices& neighbors, const std::vector<int>& phase,
+                 int64_t lower_bound, const TelamallocConfig& config,
+                 const Deadline& deadline, std::vector<int64_t>& result) {
   // Unbounded capacity never conflicts, so these incumbents are plain
   // first-fit in each tiered order and cannot fail. The winner's order also
   // steers the capacity search below.
@@ -293,7 +263,7 @@ void solve_phase(const std::vector<Allocation>& allocations,
   int64_t low = lower_bound;
 
   while (low < high) {
-    if (deadline && Clock::now() >= *deadline) {
+    if (deadline_expired(deadline)) {
       break;
     }
     const int64_t mid = low + (high - low) / 2;
@@ -323,19 +293,12 @@ std::vector<Allocation> TelamallocAllocator::allocate(
   // Bound by kUnbounded so the unbounded-capacity pack_phase incumbents in
   // solve_phase can never fail and the cursor arithmetic cannot overflow.
   check_total_size(allocations, kUnbounded);
+  const OverlapIndices neighbors = compute_overlap_indices(allocations);
   if (allocations.size() < 2) {
-    return first_fit_place_indexed(allocations,
-                                   compute_overlap_indices(allocations));
+    return first_fit_place_indexed(allocations, neighbors);
   }
 
-  Deadline deadline;
-  if (config_.timeout > 0.0) {
-    deadline =
-        Clock::now() + std::chrono::duration_cast<Clock::duration>(
-                           std::chrono::duration<double>(config_.timeout));
-  }
-
-  const auto neighbors = build_neighbors(allocations);
+  const Deadline deadline = make_deadline(config_.timeout);
   const auto phases = build_phases(neighbors);
 
   // Solve phases in descending load order: the global peak is the max over

--- a/src/cpp/bindings.cpp
+++ b/src/cpp/bindings.cpp
@@ -14,8 +14,8 @@
 #include <sstream>
 
 #include "allocators/best_fit.hpp"
+#include "allocators/first_fit.hpp"
 #include "allocators/greedy.hpp"
-#include "allocators/greedy_base.hpp"
 #include "allocators/simulated_annealing.hpp"
 #include "allocators/supermalloc/partition.hpp"
 #include "allocators/tabu_search.hpp"
@@ -28,6 +28,18 @@ namespace nb = nanobind;
 using namespace nb::literals;
 using namespace omnimalloc;
 
+namespace {
+
+// __str__/__repr__ via the type's operator<<
+template <typename T>
+std::string stream_str(const T& value) {
+  std::ostringstream ss;
+  ss << value;
+  return ss.str();
+}
+
+}  // namespace
+
 NB_MODULE(_cpp, m) {
   // BufferKind enum
   nb::enum_<BufferKind>(m, "BufferKind")
@@ -36,18 +48,8 @@ NB_MODULE(_cpp, m) {
       .value("INPUT", BufferKind::INPUT)
       .value("OUTPUT", BufferKind::OUTPUT)
       .def_prop_ro("is_io", [](BufferKind kind) { return is_io(kind); })
-      .def("__str__",
-           [](BufferKind kind) {
-             std::ostringstream ss;
-             ss << kind;
-             return ss.str();
-           })
-      .def("__repr__",
-           [](BufferKind kind) {
-             std::ostringstream ss;
-             ss << kind;
-             return ss.str();
-           })
+      .def("__str__", &stream_str<BufferKind>)
+      .def("__repr__", &stream_str<BufferKind>)
       .def("__hash__", std::hash<BufferKind>{});
 
   // Allocation class
@@ -72,18 +74,8 @@ NB_MODULE(_cpp, m) {
       .def("with_offset", &Allocation::with_offset, "offset"_a,
            nb::rv_policy::move)
       .def("with_kind", &Allocation::with_kind, "kind"_a, nb::rv_policy::move)
-      .def("__str__",
-           [](const Allocation& a) {
-             std::ostringstream ss;
-             ss << a;
-             return ss.str();
-           })
-      .def("__repr__",
-           [](const Allocation& a) {
-             std::ostringstream ss;
-             ss << a;
-             return ss.str();
-           })
+      .def("__str__", &stream_str<Allocation>)
+      .def("__repr__", &stream_str<Allocation>)
       // is_operator: return NotImplemented for non-Allocation operands
       // instead of raising TypeError, per the Python equality protocol
       .def("__eq__", &Allocation::operator==, nb::is_operator())

--- a/src/cpp/primitives/id_type.hpp
+++ b/src/cpp/primitives/id_type.hpp
@@ -27,10 +27,4 @@ struct IdTypeHash {
   }
 };
 
-struct IdTypeEqual {
-  bool operator()(const IdType& lhs, const IdType& rhs) const noexcept {
-    return lhs == rhs;
-  }
-};
-
 }  // namespace omnimalloc


### PR DESCRIPTION
Split greedy_base into first_fit (overlap graph + placement) and a new
local_search module (peak_of, peak_positions, initial_order,
earlier_neighbors, propose_peak_swap) so the metaheuristics share their
move-proposal code instead of keeping near-verbatim copies.

- Centralize timeout handling in defaults.hpp: make_deadline (noexcept,
  caps inf/NaN) plus a deadline_expired predicate used by every
  optional-deadline allocator; supermalloc's compute_deadline documents
  its intentionally different non-positive-timeout semantics.
- Share one placement skeleton: place_indexed<OffsetFn> hosts the
  gather-spans/place loop, with first-fit and best-fit as one-line
  instantiations (lambdas, so the offset scans stay fully inlined
  rather than degrading to an indirect call per allocation).
- Telamalloc: reuse compute_overlap_indices and first_fit_offset
  instead of a private sweep and gap walk, hoist the pack_phase scratch
  buffers out of the queue loop (one sort per pop instead of two), and
  compute the overlap graph once for both the early-return and main
  paths.
- Replace supermalloc's inline overflow guard with check_total_size,
  dedup the __str__/__repr__ bindings via stream_str, and drop the
  unused IdTypeEqual.

Verified bit-identical outputs on seeded best-fit, simulated annealing,
tabu search, and telamalloc runs (including tie-heavy and single-
allocation cases); benchmarks match the previous commit within noise
(greedy 500k allocations ~0.9 s, best-fit 100k ~150 ms, telamalloc/SA/
tabu unchanged).
