### PR TITLE
Torture-test the omni allocator and pressure engines end to end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ htmlcov/
 *.gcov.json.gz
 **/artifacts/
 
+# Benchmark script outputs (scripts/*.py --out)
+benchmark_results_*/
+stress_results_*/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,13 +54,14 @@ dev = [
   "pre-commit>=4.0.0",
   "pytest>=8.0",
   "pytest-cov>=7.0.0",
+  "pytest-xdist>=3.6.0",
   "ruff>=0.14.0",
   "ty>=0.0.1a26",
 ]
 
 [tool.scikit-build]
 wheel.packages = ["src/python/omnimalloc"]
-cmake.build-type = "Release"                         # TODO(fpedd): Cross-check with CMakeLists.txt
+cmake.build-type = "Release"                                            # TODO(fpedd): Cross-check with CMakeLists.txt
 build-dir = "build/{wheel_tag}"
 sdist.include = ["src/cpp/**"]
 sdist.exclude = [".github", "notebooks", "external"]
@@ -137,7 +138,8 @@ ignore = [
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-addopts = ["--import-mode=importlib"]
+addopts = ["--import-mode=importlib", "-m", "not slow"]
+markers = ["slow: exhaustive stress grids (deselected by default)"]
 log_cli = true
 log_cli_level = "INFO"
 log_cli_format = "%(asctime)s [%(levelname)s] %(message)s (%(filename)s:%(lineno)d)"

--- a/scripts/benchmark_allocation.py
+++ b/scripts/benchmark_allocation.py
@@ -48,6 +48,7 @@ NUM_SYNCS = (0, 64, 1_024)
 # fall back to peak-bound sanity checks on larger instances
 VALIDATE_LIMIT = 2_000
 ALLOCATORS = (
+    "omni_allocator",
     "greedy_by_all_allocator_cpp",
     "greedy_allocator_cpp",
     "best_fit_allocator",

--- a/scripts/benchmark_pressure.py
+++ b/scripts/benchmark_pressure.py
@@ -11,7 +11,8 @@ antichain) against the two exact C++ methods:
   reference every ratio is measured against
 - ``get_closure_pressure``: realizable peak via join-closure enumeration;
   instances whose closure exceeds ``--closure-cap`` are reported as capped
-  and excluded from the means
+  and excluded from the means. Instances where ``get_pressure`` exceeds its
+  default work budget are reported the same way
 
 and their per-allocation counterparts (dashed in the figures; ratios are
 means over the per-allocation pinned antichain):
@@ -125,6 +126,14 @@ def _capped(
         return None
 
 
+def _budgeted(allocations: tuple[Allocation, ...]) -> Value:
+    """None instead of raising when get_pressure exceeds its work budget."""
+    try:
+        return get_pressure(allocations)
+    except RuntimeError:
+        return None
+
+
 def _sample_runners(
     allocations: tuple[Allocation, ...],
     placed: tuple[Allocation, ...],
@@ -132,7 +141,7 @@ def _sample_runners(
     args: argparse.Namespace,
 ) -> dict[str, Runner]:
     return {
-        "get_pressure": lambda: get_pressure(allocations),
+        "get_pressure": lambda: _budgeted(allocations),
         REFERENCE: lambda: get_antichain_pressure(allocations),
         "get_closure_pressure": lambda: _capped(
             get_closure_pressure, allocations, args.closure_cap

--- a/scripts/stress_omni.py
+++ b/scripts/stress_omni.py
@@ -1,0 +1,292 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Stress the omni allocator across clock dimensions and concurrent callers.
+
+Complements ``scripts/benchmark_allocation.py`` (problem-size and sync-density
+sweeps) and ``scripts/benchmark_pressure.py`` (exact pressure engines) with
+the two axes both hold fixed:
+
+- dimension sweep: wall time and packing quality versus the clock dimension
+  (source ``num_threads``) at a fixed problem size, one series per sync
+  pattern. Quality is peak over the budgeted exact lower bound
+  (``get_pressure``); instances whose bound exceeds the work budget are
+  reported without a ratio rather than stalling the sweep.
+- caller sweep: aggregate throughput versus concurrent Python callers on one
+  fixed instance. The bindings release the GIL and the C++ portfolio spawns
+  its own workers per call, so this measures how caller-level and internal
+  parallelism compose. Every concurrent result is checked against the serial
+  placement, so the sweep doubles as a determinism/race torture pass.
+
+    uv run python scripts/stress_omni.py --out stress_results_omni
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+from math import isnan, nan
+from pathlib import Path
+from statistics import mean
+from typing import TYPE_CHECKING
+
+import matplotlib.pyplot as plt
+from omnimalloc.allocators import OmniAllocator
+from omnimalloc.benchmark.sources.sync_patterns import SYNC_PATTERNS, SyncPatternSource
+from omnimalloc.benchmark.timer import Timer
+from omnimalloc.primitives.pressure import get_pressure
+
+if TYPE_CHECKING:
+    from matplotlib.axes import Axes
+    from matplotlib.figure import Figure
+    from omnimalloc.primitives import Allocation
+
+DIMS = (2, 4, 8, 16, 32, 64)
+PATTERNS = ("independent", "sparse", "barrier", "dense")
+CALLERS = (1, 2, 4, 8, 16, 32)
+
+SURFACE = "#fcfcfb"
+INK = "#0b0b0b"
+INK_SECONDARY = "#52514e"
+INK_MUTED = "#898781"
+GRID = "#e1e0d9"
+AXIS = "#c3c2b7"
+# House palette (see benchmark_allocation.py), most-separated hues first;
+# per-series markers keep identity readable without color
+SERIES = ("#2a78d6", "#1baf7a", "#eda100", "#e34948", "#4a3aa7", "#008300", "#e87ba4")
+MARKERS = ("o", "s", "^", "D", "v", "P", "X")
+
+
+def _peak(placed: tuple[Allocation, ...]) -> int:
+    heights = [alloc.height for alloc in placed if alloc.height is not None]
+    return max(heights, default=0)
+
+
+def _timed_allocate(
+    allocations: tuple[Allocation, ...], repeats: int
+) -> tuple[float, tuple[Allocation, ...]]:
+    seconds = []
+    placed: tuple[Allocation, ...] = ()
+    for _ in range(repeats):
+        timer = Timer(auto_start=True)
+        placed = OmniAllocator().allocate(allocations)
+        timer.stop()
+        seconds.append(timer.elapsed_s)
+    return min(seconds), placed
+
+
+def _bounded_ratio(
+    allocations: tuple[Allocation, ...], peak: int, work_budget: int
+) -> float:
+    """Peak over the budgeted exact bound; NaN when the budget is exceeded."""
+    try:
+        return peak / get_pressure(allocations, work_budget=work_budget)
+    except RuntimeError:
+        return nan
+
+
+def dim_sweep(args: argparse.Namespace) -> dict[str, dict[int, tuple[float, float]]]:
+    results: dict[str, dict[int, tuple[float, float]]] = {}
+    for pattern in args.patterns:
+        results[pattern] = {}
+        for dim in args.dims:
+            times = []
+            ratios = []
+            for rep in range(args.repeats):
+                allocations = SyncPatternSource(
+                    num_allocations=args.size,
+                    num_threads=dim,
+                    pattern=pattern,
+                    seed=args.seed + rep,
+                ).get_allocations()
+                seconds, placed = _timed_allocate(allocations, repeats=1)
+                times.append(seconds)
+                ratios.append(
+                    _bounded_ratio(allocations, _peak(placed), args.work_budget)
+                )
+            clean = [r for r in ratios if not isnan(r)]
+            results[pattern][dim] = (min(times), mean(clean) if clean else nan)
+            print(
+                f"dim sweep: pattern={pattern} dim={dim} "
+                f"time={min(times):.3f}s ratio={results[pattern][dim][1]:.3f}"
+            )
+    return results
+
+
+def caller_sweep(args: argparse.Namespace) -> dict[int, float]:
+    allocations = SyncPatternSource(
+        num_allocations=args.size,
+        num_threads=8,
+        pattern="sparse",
+        seed=args.seed,
+    ).get_allocations()
+    expected = [a.offset for a in OmniAllocator().allocate(allocations)]
+
+    def run_once(_: int) -> list[int | None]:
+        return [a.offset for a in OmniAllocator().allocate(allocations)]
+
+    throughput: dict[int, float] = {}
+    for callers in args.callers:
+        with ThreadPoolExecutor(max_workers=callers) as executor:
+            timer = Timer(auto_start=True)
+            offsets = list(executor.map(run_once, range(args.calls)))
+            timer.stop()
+        if any(result != expected for result in offsets):
+            raise AssertionError(f"non-deterministic placement with {callers} callers")
+        throughput[callers] = args.calls / timer.elapsed_s
+        print(
+            f"caller sweep: callers={callers} wall={timer.elapsed_s:.2f}s "
+            f"calls/s={throughput[callers]:.1f} "
+            f"speedup={throughput[callers] / throughput[args.callers[0]]:.2f}x"
+        )
+    return throughput
+
+
+def _style_axes(ax: Axes) -> None:
+    ax.set_facecolor(SURFACE)
+    ax.grid(visible=True, which="major", color=GRID, linewidth=0.8)
+    ax.set_axisbelow(True)
+    ax.tick_params(colors=INK_MUTED, labelcolor=INK_SECONDARY, labelsize=9)
+    for side in ("top", "right"):
+        ax.spines[side].set_visible(False)
+    for side in ("bottom", "left"):
+        ax.spines[side].set_color(AXIS)
+
+
+def _plot_series(
+    ax: Axes,
+    xs: list[int],
+    values: list[float],
+    label: str,
+    color: str,
+    marker: str,
+) -> None:
+    if all(isnan(value) for value in values):
+        return
+    ax.plot(
+        xs,
+        values,
+        label=label,
+        color=color,
+        linewidth=2,
+        marker=marker,
+        markersize=5.5,
+        markeredgecolor=SURFACE,
+        markeredgewidth=1,
+    )
+
+
+def _titles(ax: Axes, title: str, caption: str) -> None:
+    ax.set_title(title, loc="left", color=INK, fontsize=12, fontweight="medium", pad=22)
+    note = ax.text(
+        0.0, 1.04, caption, transform=ax.transAxes, fontsize=8.5, color=INK_MUTED
+    )
+    note.set_in_layout(False)
+
+
+def render_dim_sweep(
+    results: dict[str, dict[int, tuple[float, float]]], args: argparse.Namespace
+) -> Figure:
+    fig, (ax_time, ax_ratio) = plt.subplots(
+        2,
+        1,
+        sharex=True,
+        figsize=(8, 6.4),
+        height_ratios=(3, 1.4),
+        layout="constrained",
+    )
+    fig.set_facecolor(SURFACE)
+    dims = list(args.dims)
+    for (pattern, by_dim), color, marker in zip(
+        results.items(), SERIES, MARKERS, strict=False
+    ):
+        _plot_series(
+            ax_time, dims, [by_dim[d][0] for d in dims], pattern, color, marker
+        )
+        _plot_series(
+            ax_ratio, dims, [by_dim[d][1] for d in dims], pattern, color, marker
+        )
+    _style_axes(ax_time)
+    ax_time.set_yscale("log")
+    ax_time.set_xscale("log", base=2)
+    ax_time.set_xticks(dims, [str(d) for d in dims])
+    ax_time.tick_params(which="minor", bottom=False)
+    ax_time.set_ylabel("wall time [s]", color=INK_SECONDARY, fontsize=10)
+    _titles(
+        ax_time,
+        "omni allocator vs clock dimension",
+        f"{args.size:,} allocations, best of {args.repeats} seeds per point",
+    )
+    ax_time.legend(frameon=False, fontsize=8.5, labelcolor=INK_SECONDARY)
+    _style_axes(ax_ratio)
+    ax_ratio.axhline(1.0, color=AXIS, linewidth=1)
+    ax_ratio.set_ylabel("peak /\nexact bound", color=INK_SECONDARY, fontsize=9)
+    ax_ratio.set_xlabel("clock dimension [threads]", color=INK_SECONDARY, fontsize=10)
+    return fig
+
+
+def render_caller_sweep(
+    throughput: dict[int, float], args: argparse.Namespace
+) -> Figure:
+    fig, ax = plt.subplots(figsize=(8, 4.4), layout="constrained")
+    fig.set_facecolor(SURFACE)
+    callers = list(throughput)
+    ideal = [throughput[callers[0]] * c / callers[0] for c in callers]
+    ax.plot(callers, ideal, color=AXIS, linewidth=1, linestyle="--", label="ideal")
+    _plot_series(
+        ax, callers, [throughput[c] for c in callers], "measured", SERIES[0], "o"
+    )
+    _style_axes(ax)
+    ax.set_xscale("log", base=2)
+    ax.set_xticks(callers, [str(c) for c in callers])
+    ax.tick_params(which="minor", bottom=False)
+    ax.set_ylabel("allocate calls / s", color=INK_SECONDARY, fontsize=10)
+    ax.set_xlabel("concurrent Python callers", color=INK_SECONDARY, fontsize=10)
+    _titles(
+        ax,
+        "omni allocator throughput vs concurrent callers",
+        f"{args.calls} calls on one {args.size:,}-allocation sparse instance, "
+        "results checked against the serial placement",
+    )
+    ax.legend(frameon=False, fontsize=8.5, labelcolor=INK_SECONDARY, loc="upper left")
+    return fig
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--size", type=int, default=4_000)
+    parser.add_argument("--dims", type=int, nargs="+", default=list(DIMS))
+    parser.add_argument(
+        "--patterns", nargs="+", choices=SYNC_PATTERNS, default=list(PATTERNS)
+    )
+    parser.add_argument("--callers", type=int, nargs="+", default=list(CALLERS))
+    parser.add_argument("--calls", type=int, default=64)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--work-budget",
+        type=int,
+        default=4_000_000_000,
+        help="pressure-bound work budget; exceeded points plot without a ratio",
+    )
+    parser.add_argument("--out", type=Path, default=Path("stress_results_omni"))
+    args = parser.parse_args()
+
+    results = dim_sweep(args)
+    throughput = caller_sweep(args)
+
+    args.out.mkdir(parents=True, exist_ok=True)
+    figures = {
+        "dim_sweep": render_dim_sweep(results, args),
+        "caller_sweep": render_caller_sweep(throughput, args),
+    }
+    for name, figure in figures.items():
+        figure.savefig(args.out / f"{name}.pdf")
+        plt.close(figure)
+    print(f"wrote figures to {args.out}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_omni_torture.py
+++ b/tests/integration/test_omni_torture.py
@@ -1,0 +1,457 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import itertools
+import random
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from omnimalloc._cpp import FirstFitPlacer, compute_temporal_overlaps
+from omnimalloc.allocators import OmniAllocator
+from omnimalloc.allocators.greedy_cpp import (
+    GreedyAllocatorCpp,
+    GreedyByAreaAllocatorCpp,
+    GreedyByConflictAllocatorCpp,
+    GreedyByConflictSizeAllocatorCpp,
+    GreedyByDurationAllocatorCpp,
+    GreedyBySizeAllocatorCpp,
+    GreedyByStartAllocatorCpp,
+)
+from omnimalloc.benchmark.sources.concurrent_tiling import ConcurrentTilingSource
+from omnimalloc.benchmark.sources.generator import HighContentionSource, RandomSource
+from omnimalloc.benchmark.sources.pinwheel import PinwheelSource
+from omnimalloc.benchmark.sources.sync_patterns import SYNC_PATTERNS, SyncPatternSource
+from omnimalloc.benchmark.sources.tiling import TilingSource
+from omnimalloc.primitives import Allocation, Pool
+from omnimalloc.primitives.pressure import (
+    get_antichain_pressure,
+    get_closure_pressure,
+    get_per_allocation_placement_pressure,
+    get_pressure,
+)
+from omnimalloc.validate import validate_allocation
+
+GREEDY_PORTFOLIO = (
+    GreedyAllocatorCpp,
+    GreedyBySizeAllocatorCpp,
+    GreedyByDurationAllocatorCpp,
+    GreedyByAreaAllocatorCpp,
+    GreedyByConflictAllocatorCpp,
+    GreedyByConflictSizeAllocatorCpp,
+    GreedyByStartAllocatorCpp,
+)
+
+
+def _peak(allocations: tuple[Allocation, ...]) -> int:
+    return max(a.offset + a.size for a in allocations)
+
+
+def _assert_conflicting_pairs_disjoint(placed: tuple[Allocation, ...]) -> None:
+    by_id = {a.id: a for a in placed}
+    for alloc_id, neighbor_ids in compute_temporal_overlaps(placed).items():
+        a = by_id[alloc_id]
+        for neighbor_id in neighbor_ids:
+            b = by_id[neighbor_id]
+            assert a.offset + a.size <= b.offset or b.offset + b.size <= a.offset
+
+
+def _certify(
+    allocations: tuple[Allocation, ...], placed: tuple[Allocation, ...]
+) -> int:
+    peak = _peak(placed)
+    assert get_antichain_pressure(allocations) <= peak
+    assert peak <= sum(a.size for a in allocations)
+    assert max(get_per_allocation_placement_pressure(placed).values()) == peak
+    _assert_conflicting_pairs_disjoint(placed)
+    return peak
+
+
+def _random_scalar(n: int, seed: int, horizon: int = 50) -> tuple[Allocation, ...]:
+    rng = random.Random(seed)
+    allocations = []
+    for i in range(n):
+        start = rng.randint(0, horizon)
+        allocations.append(
+            Allocation(
+                id=i,
+                size=rng.randint(1, 128),
+                start=start,
+                end=start + rng.randint(1, 20),
+            )
+        )
+    return tuple(allocations)
+
+
+def _random_vector_instance(rng: random.Random) -> tuple[Allocation, ...]:
+    dim = rng.choice((2, 3))
+    allocations = []
+    for i in range(rng.randint(4, 7)):
+        start = tuple(rng.randint(0, 4) for _ in range(dim))
+        delta = [rng.randint(0, 3) for _ in range(dim)]
+        if sum(delta) == 0:
+            delta[rng.randrange(dim)] = 1
+        end = tuple(s + d for s, d in zip(start, delta, strict=True))
+        allocations.append(
+            Allocation(id=i, size=rng.randint(1, 100), start=start, end=end)
+        )
+    return tuple(allocations)
+
+
+def _tiled_crowns(num_crowns: int) -> tuple[Allocation, ...]:
+    allocations = []
+    for j in range(num_crowns):
+        b = 3 * j
+        allocations.extend(
+            (
+                Allocation(id=4 * j, size=8, start=(b, b), end=(b + 1, b)),
+                Allocation(id=4 * j + 1, size=16, start=(b + 1, b), end=(b + 2, b)),
+                Allocation(id=4 * j + 2, size=32, start=(b, b), end=(b, b + 1)),
+                Allocation(id=4 * j + 3, size=64, start=(b, b + 1), end=(b, b + 2)),
+            )
+        )
+    return tuple(allocations)
+
+
+@pytest.mark.parametrize("pattern", SYNC_PATTERNS)
+@pytest.mark.parametrize("num_threads", [2, 4])
+def test_sync_pattern_placement_is_certified(pattern: str, num_threads: int) -> None:
+    source = SyncPatternSource(
+        num_allocations=64, num_threads=num_threads, pattern=pattern
+    )
+    allocations = source.get_allocations()
+    placed = OmniAllocator().allocate(allocations)
+    validate_allocation(Pool(id="p", allocations=placed))
+    _certify(allocations, placed)
+
+
+@pytest.mark.parametrize("pattern", SYNC_PATTERNS)
+def test_closure_antichain_peak_chain_on_sync_patterns(pattern: str) -> None:
+    source = SyncPatternSource(num_allocations=32, num_threads=3, pattern=pattern)
+    allocations = source.get_allocations()
+    peak = _peak(OmniAllocator().allocate(allocations))
+    closure = get_closure_pressure(allocations, closure_cap=1 << 18)
+    antichain = get_antichain_pressure(allocations)
+    assert closure <= antichain <= peak
+    assert get_pressure(allocations) == antichain
+
+
+@pytest.mark.parametrize("num_threads", [2, 4])
+@pytest.mark.parametrize("num_syncs", [0, 16, 256])
+def test_concurrent_tiling_is_certified_near_optimum(
+    num_threads: int, num_syncs: int
+) -> None:
+    capacity = 1024 * 1024
+    source = ConcurrentTilingSource(
+        num_allocations=96,
+        num_threads=num_threads,
+        num_syncs=num_syncs,
+        capacity=capacity,
+    )
+    allocations = source.get_allocations()
+    placed = OmniAllocator().allocate(allocations)
+    peak = _certify(allocations, placed)
+    assert get_antichain_pressure(allocations) <= capacity
+    assert capacity <= peak <= 2 * capacity
+
+
+@pytest.mark.parametrize("source_cls", [TilingSource, PinwheelSource])
+@pytest.mark.parametrize("num_allocations", [128, 512])
+def test_scalar_tiling_peak_stays_near_known_optimum(
+    source_cls: type[TilingSource] | type[PinwheelSource], num_allocations: int
+) -> None:
+    capacity = 1024 * 1024
+    source = source_cls(num_allocations=num_allocations, capacity=capacity)
+    allocations = source.get_allocations()
+    placed = OmniAllocator().allocate(allocations)
+    peak = _certify(allocations, placed)
+    assert capacity <= peak <= 2 * capacity
+
+
+def test_scalar_portfolio_not_worse_than_any_greedy_variant() -> None:
+    sources = (
+        RandomSource(num_allocations=200, seed=5),
+        HighContentionSource(num_allocations=200, time_window=12, seed=5),
+        TilingSource(num_allocations=256, seed=5),
+    )
+    for source in sources:
+        allocations = source.get_allocations()
+        omni_peak = _peak(OmniAllocator().allocate(allocations))
+        for variant_cls in GREEDY_PORTFOLIO:
+            assert omni_peak <= _peak(variant_cls().allocate(allocations))
+
+
+def test_vector_not_worse_than_input_order_greedy() -> None:
+    for pattern in ("independent", "ring", "barrier", "dense"):
+        source = SyncPatternSource(num_allocations=96, num_threads=5, pattern=pattern)
+        allocations = source.get_allocations()
+        omni_peak = _peak(OmniAllocator().allocate(allocations))
+        assert omni_peak <= _peak(GreedyAllocatorCpp().allocate(allocations))
+
+
+def test_size_scaling_scales_peak_linearly() -> None:
+    source = SyncPatternSource(num_allocations=80, num_threads=4, pattern="sparse")
+    allocations = source.get_allocations()
+    scaled = tuple(
+        Allocation(id=a.id, size=7 * a.size, start=a.start, end=a.end)
+        for a in allocations
+    )
+    assert _peak(OmniAllocator().allocate(scaled)) == 7 * _peak(
+        OmniAllocator().allocate(allocations)
+    )
+
+
+def test_clock_translation_preserves_offsets() -> None:
+    source = SyncPatternSource(num_allocations=80, num_threads=4, pattern="groups")
+    allocations = source.get_allocations()
+    translated = tuple(
+        Allocation(
+            id=a.id,
+            size=a.size,
+            start=tuple(t + 1000 for t in a.start),
+            end=tuple(t + 1000 for t in a.end),
+        )
+        for a in allocations
+    )
+    assert [x.offset for x in OmniAllocator().allocate(translated)] == [
+        x.offset for x in OmniAllocator().allocate(allocations)
+    ]
+
+
+def test_lane_permutation_preserves_exact_pressures() -> None:
+    source = SyncPatternSource(num_allocations=48, num_threads=4, pattern="fork_join")
+    allocations = source.get_allocations()
+    lanes = (2, 0, 3, 1)
+    permuted = tuple(
+        Allocation(
+            id=a.id,
+            size=a.size,
+            start=tuple(a.start[lane] for lane in lanes),
+            end=tuple(a.end[lane] for lane in lanes),
+        )
+        for a in allocations
+    )
+    assert get_antichain_pressure(permuted) == get_antichain_pressure(allocations)
+    assert get_closure_pressure(permuted, closure_cap=1 << 18) == get_closure_pressure(
+        allocations, closure_cap=1 << 18
+    )
+    _certify(permuted, OmniAllocator().allocate(permuted))
+
+
+def test_zero_lane_padding_preserves_offsets() -> None:
+    source = SyncPatternSource(num_allocations=64, num_threads=3, pattern="ring")
+    allocations = source.get_allocations()
+    padded = tuple(
+        Allocation(id=a.id, size=a.size, start=(*a.start, 0, 0), end=(*a.end, 0, 0))
+        for a in allocations
+    )
+    assert [x.offset for x in OmniAllocator().allocate(padded)] == [
+        x.offset for x in OmniAllocator().allocate(allocations)
+    ]
+
+
+@pytest.mark.parametrize("dim", [2, 8])
+def test_lockstep_embedding_matches_scalar_peak(dim: int) -> None:
+    allocations = _random_scalar(300, seed=9)
+    lockstep = tuple(
+        Allocation(id=a.id, size=a.size, start=(a.start,) * dim, end=(a.end,) * dim)
+        for a in allocations
+    )
+    assert _peak(OmniAllocator().allocate(lockstep)) == _peak(
+        OmniAllocator().allocate(allocations)
+    )
+
+
+@pytest.mark.parametrize("dim", [2, 8, 32])
+def test_one_hot_lanes_reach_the_exact_optimum(dim: int) -> None:
+    size = 64
+    allocations = tuple(
+        Allocation(
+            id=lane * 1000 + step,
+            size=size,
+            start=tuple(step if t == lane else 0 for t in range(dim)),
+            end=tuple(step + 1 if t == lane else 0 for t in range(dim)),
+        )
+        for lane in range(dim)
+        for step in range(8)
+    )
+    placed = OmniAllocator().allocate(allocations)
+    peak = _certify(allocations, placed)
+    assert peak == dim * size
+    assert get_antichain_pressure(allocations) == dim * size
+
+
+def test_total_order_chain_peak_is_max_size() -> None:
+    rng = random.Random(3)
+    sizes = [rng.randint(1, 4096) for _ in range(1000)]
+    scalar = tuple(
+        Allocation(id=i, size=s, start=i, end=i + 1) for i, s in enumerate(sizes)
+    )
+    lockstep = tuple(
+        Allocation(id=i, size=s, start=(i,) * 4, end=(i + 1,) * 4)
+        for i, s in enumerate(sizes)
+    )
+    assert _peak(OmniAllocator().allocate(scalar)) == max(sizes)
+    assert _peak(OmniAllocator().allocate(lockstep)) == max(sizes)
+
+
+def test_full_antichain_peak_is_total_size() -> None:
+    rng = random.Random(4)
+    sizes = [rng.randint(1, 4096) for _ in range(512)]
+    allocations = tuple(
+        Allocation(id=i, size=s, start=0, end=1) for i, s in enumerate(sizes)
+    )
+    placed = OmniAllocator().allocate(allocations)
+    assert _peak(placed) == sum(sizes)
+    _assert_conflicting_pairs_disjoint(placed)
+
+
+def test_identical_vector_lifetimes_stack_to_total_size() -> None:
+    allocations = tuple(
+        Allocation(id=i, size=8 + i % 5, start=(1, 1, 1), end=(2, 2, 2))
+        for i in range(512)
+    )
+    placed = OmniAllocator().allocate(allocations)
+    assert _peak(placed) == sum(a.size for a in allocations)
+    _assert_conflicting_pairs_disjoint(placed)
+
+
+def test_extreme_clock_values_and_sizes_place_validly() -> None:
+    big = 10**18
+    allocations = tuple(
+        Allocation(
+            id=i,
+            size=2**40 + i,
+            start=(big + i, big - i),
+            end=(big + i + 1, big - i + 1),
+        )
+        for i in range(16)
+    )
+    placed = OmniAllocator().allocate(allocations)
+    peak = _certify(allocations, placed)
+    assert peak == sum(a.size for a in allocations)
+
+
+def test_tiled_crowns_are_certified_and_exact() -> None:
+    allocations = _tiled_crowns(50)
+    assert get_antichain_pressure(allocations) == 80
+    assert get_pressure(allocations) == 80
+    placed = OmniAllocator().allocate(allocations)
+    assert _certify(allocations, placed) >= 80
+
+
+def test_pressure_budget_raises_but_default_succeeds_on_crowns() -> None:
+    allocations = _tiled_crowns(50)
+    with pytest.raises(RuntimeError, match="work_budget"):
+        get_pressure(allocations, work_budget=1)
+    assert get_pressure(allocations) == get_antichain_pressure(allocations)
+
+
+def test_exhaustive_first_fit_orders_bracket_omni_peak() -> None:
+    rng = random.Random(21)
+    for _ in range(15):
+        allocations = _random_vector_instance(rng)
+        placer = FirstFitPlacer(list(allocations))
+        best = min(
+            placer.evaluate(list(order))
+            for order in itertools.permutations(range(len(allocations)))
+        )
+        omni_peak = _peak(OmniAllocator().allocate(allocations))
+        closure = get_closure_pressure(allocations)
+        antichain = get_antichain_pressure(allocations)
+        assert closure <= antichain <= best <= omni_peak
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("pattern", SYNC_PATTERNS)
+@pytest.mark.parametrize("num_threads", [8, 16])
+@pytest.mark.parametrize("seed", [0, 1, 2])
+def test_torture_sync_pattern_grid(pattern: str, num_threads: int, seed: int) -> None:
+    source = SyncPatternSource(
+        num_allocations=2048, num_threads=num_threads, pattern=pattern, seed=seed
+    )
+    allocations = source.get_allocations()
+    placed = OmniAllocator().allocate(allocations)
+    _certify(allocations, placed)
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("num_threads", [4, 8])
+@pytest.mark.parametrize("num_syncs", [0, 64, 4096])
+def test_torture_concurrent_tiling_scale(num_threads: int, num_syncs: int) -> None:
+    capacity = 1024 * 1024
+    source = ConcurrentTilingSource(
+        num_allocations=8192,
+        num_threads=num_threads,
+        num_syncs=num_syncs,
+        capacity=capacity,
+    )
+    allocations = source.get_allocations()
+    placed = OmniAllocator().allocate(allocations)
+    peak = _certify(allocations, placed)
+    assert get_antichain_pressure(allocations) <= capacity
+    assert capacity <= peak <= 2 * capacity
+
+
+@pytest.mark.slow
+def test_torture_lockstep_scale_matches_scalar() -> None:
+    allocations = _random_scalar(20000, seed=17, horizon=20000)
+    lockstep = tuple(
+        Allocation(id=a.id, size=a.size, start=(a.start,) * 32, end=(a.end,) * 32)
+        for a in allocations
+    )
+    scalar_placed = OmniAllocator().allocate(allocations)
+    lockstep_placed = OmniAllocator().allocate(lockstep)
+    assert _peak(lockstep_placed) == _peak(scalar_placed)
+    _assert_conflicting_pairs_disjoint(lockstep_placed)
+
+
+@pytest.mark.slow
+def test_torture_sparse_sync_at_scale_is_certified() -> None:
+    source = SyncPatternSource(
+        num_allocations=8000, num_threads=16, pattern="sparse", sync_period=4
+    )
+    allocations = source.get_allocations()
+    placed = OmniAllocator().allocate(allocations)
+    _certify(allocations, placed)
+
+
+@pytest.mark.slow
+def test_torture_scalar_scale_is_certified() -> None:
+    allocations = _random_scalar(50000, seed=23, horizon=50000)
+    placed = OmniAllocator().allocate(allocations)
+    _certify(allocations, placed)
+
+
+@pytest.mark.slow
+def test_torture_concurrent_hammer_is_deterministic() -> None:
+    source = SyncPatternSource(num_allocations=256, num_threads=8, pattern="sparse")
+    allocations = source.get_allocations()
+    expected = [a.offset for a in OmniAllocator().allocate(allocations)]
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        results = list(
+            executor.map(lambda _: OmniAllocator().allocate(allocations), range(512))
+        )
+    assert all([a.offset for a in placed] == expected for placed in results)
+
+
+@pytest.mark.slow
+def test_torture_concurrent_mixed_instances_stay_isolated() -> None:
+    instances = tuple(
+        SyncPatternSource(
+            num_allocations=256, num_threads=4, pattern=pattern, seed=seed
+        ).get_allocations()
+        for pattern in SYNC_PATTERNS
+        for seed in range(16)
+    )
+    serial_peaks = [_peak(OmniAllocator().allocate(a)) for a in instances]
+    serial_pressures = [get_antichain_pressure(a) for a in instances]
+    with ThreadPoolExecutor(max_workers=32) as executor:
+        parallel_placed = list(
+            executor.map(lambda a: OmniAllocator().allocate(a), instances)
+        )
+        parallel_pressures = list(executor.map(get_antichain_pressure, instances))
+    assert [_peak(p) for p in parallel_placed] == serial_peaks
+    assert parallel_pressures == serial_pressures
+    for allocations, placed in zip(instances, parallel_placed, strict=True):
+        _certify(allocations, placed)

--- a/tests/integration/test_supermalloc.py
+++ b/tests/integration/test_supermalloc.py
@@ -13,6 +13,7 @@ from omnimalloc.visualize import HAS_MATPLOTLIB
 ALLOCATORS = (
     "greedy_by_size_allocator_cpp",
     "greedy_by_all_allocator_cpp",
+    "omni_allocator",
     SupermallocAllocator(SupermallocConfig(timeout=2)),
 ) + ((MinimallocAllocator(timeout=2),) if HAS_MINIMALLOC else ())
 

--- a/tests/unit/allocators/test_vector_time.py
+++ b/tests/unit/allocators/test_vector_time.py
@@ -22,6 +22,7 @@ from omnimalloc.allocators.greedy_cpp import GreedyAllocatorCpp
 from omnimalloc.allocators.hillclimb import HillClimbAllocator
 from omnimalloc.allocators.minimalloc import HAS_MINIMALLOC, MinimallocAllocator
 from omnimalloc.allocators.naive import NaiveAllocator
+from omnimalloc.allocators.omni import OmniAllocator
 from omnimalloc.allocators.random import RandomAllocator
 from omnimalloc.allocators.simulated_annealing import (
     SimulatedAnnealingAllocator,
@@ -53,6 +54,7 @@ def vector_problem(n: int = 10) -> tuple[Allocation, ...]:
         GreedyAllocator,
         GreedyAllocatorCpp,
         NaiveAllocator,
+        OmniAllocator,
         RandomAllocator,
         HillClimbAllocator,
         BestFitAllocator,
@@ -194,6 +196,7 @@ def test_minimalloc_rejects_vector_time() -> None:
 def test_registry_declares_vector_time_support() -> None:
     registry = BaseAllocator.registry()
     assert registry["greedy_allocator"].supports_vector_time
+    assert registry["omni_allocator"].supports_vector_time
     assert registry["best_fit_allocator"].supports_vector_time
     assert registry["simulated_annealing_allocator"].supports_vector_time
     assert registry["tabu_search_allocator"].supports_vector_time

--- a/uv.lock
+++ b/uv.lock
@@ -577,6 +577,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1575,6 +1584,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
 ]
@@ -1599,6 +1609,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.0" },
     { name = "ruff", specifier = ">=0.14.0" },
     { name = "ty", specifier = ">=0.0.1a26" },
 ]
@@ -1945,6 +1956,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add tests/integration/test_omni_torture.py: every placement is certified
through the oracle sandwich (closure <= antichain <= peak <= total size,
placement-pressure max == peak, per-conflict-pair spatial disjointness)
across all sync patterns, tiling sweeps, metamorphic transforms (size
scaling, clock translation, lane permutation, zero-lane padding, lockstep
embedding to dim 32), closed-form adversarial shapes (one-hot lanes,
chains, antichains, identical lifetimes, tiled 2+2 crowns, int64-edge
values), the documented 7-order portfolio contract, and an exhaustive
small-N bracket against all first-fit orders. Heavy grids (N up to 50k,
32-thread determinism hammers) carry a new `slow` marker, registered in
pyproject and deselected by default; run them with `pytest -m slow`.

Wire the omni allocator into the existing suites: the vector-time
allocator lists and registry assertions, and the benchmark integration
loop. Add pytest-xdist to the dev group for parallel runs.

Extend the benchmark tooling along the two axes the existing scripts hold
fixed: scripts/stress_omni.py sweeps the clock dimension (quality vs the
budgeted exact bound) and concurrent Python callers (GIL-released
throughput with determinism verification). Add the omni allocator to the
benchmark_allocation defaults. In benchmark_pressure, record instances
where get_pressure exceeds its work budget as capped instead of crashing
the sweep (first hit at size 10k on the independent pattern). Ignore the
scripts' output directories in git.
