### PR TITLE
Shrink the top-level namespace to eight names

### DIFF
--- a/notebooks/custom_allocator.ipynb
+++ b/notebooks/custom_allocator.ipynb
@@ -32,6 +32,7 @@
    "source": [
     "import omnimalloc as om\n",
     "from omnimalloc.allocators import BaseAllocator, available_allocators\n",
+    "from omnimalloc.analysis import conflicts\n",
     "from omnimalloc.benchmark.sources import RandomSource"
    ]
   },
@@ -43,7 +44,7 @@
     "`_allocate` receives validated, non-empty allocations with unique ids and\n",
     "returns them with offsets assigned. The one constraint to satisfy:\n",
     "*conflicting* allocations, those whose lifetimes can coexist, as reported\n",
-    "by `om.conflicts`, must occupy disjoint address ranges.\n",
+    "by `omnimalloc.analysis.conflicts`, must occupy disjoint address ranges.\n",
     "\n",
     "This allocator places largest-first, each allocation at the lowest offset\n",
     "not blocked by an already-placed conflict. Because it consumes only the\n",
@@ -73,10 +74,10 @@
     "    def _allocate(\n",
     "        self, allocations: tuple[om.Allocation, ...]\n",
     "    ) -> tuple[om.Allocation, ...]:\n",
-    "        conflict_map = om.conflicts(allocations)\n",
+    "        conflict_map = conflicts(allocations)\n",
     "        sizes = {alloc.id: alloc.size for alloc in allocations}\n",
     "        # Pins are obstacles from the first scan on, and never move\n",
-    "        offsets: dict[om.IdType, int] = {\n",
+    "        offsets: dict[int | str, int] = {\n",
     "            alloc.id: alloc.offset\n",
     "            for alloc in allocations\n",
     "            if alloc.offset is not None\n",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ ignore = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["--import-mode=importlib", "-m", "not slow"]
+pythonpath = ["."] # importlib mode drops it; spawned workers import tests from it
 markers = ["slow: exhaustive stress grids (deselected by default)"]
 log_cli = true
 log_cli_level = "INFO"

--- a/scripts/benchmark_pressure.py
+++ b/scripts/benchmark_pressure.py
@@ -14,7 +14,7 @@ from statistics import mean
 from typing import TYPE_CHECKING, Any
 
 import matplotlib.pyplot as plt
-from omnimalloc import OmniAllocator
+from omnimalloc.allocators import OmniAllocator
 from omnimalloc.analysis import (
     closure_pressure,
     closure_pressure_per_allocation,

--- a/src/python/omnimalloc/__init__.py
+++ b/src/python/omnimalloc/__init__.py
@@ -2,25 +2,24 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-from importlib.metadata import version
+"""Static memory allocation: place buffers with temporal bounds, minimize peak."""
 
-__version__ = version("omnimalloc")
+from importlib.metadata import version as _version
 
-from ._allocate import allocate as allocate
-from .allocators import OmniAllocator as OmniAllocator
-from .analysis import conflicts as conflicts
-from .analysis import pressure as pressure
-from .analysis import try_linearize as try_linearize
-from .common.parallel import max_threads as max_threads
-from .common.parallel import set_max_threads as set_max_threads
-from .io import load_allocation as load_allocation
-from .io import save_allocation as save_allocation
-from .primitives import Allocation as Allocation
-from .primitives import AllocationKind as AllocationKind
-from .primitives import IdType as IdType
-from .primitives import Memory as Memory
-from .primitives import Pool as Pool
-from .primitives import System as System
-from .primitives import TimePoint as TimePoint
-from .validate import validate_allocation as validate_allocation
-from .visualize import plot_allocation as plot_allocation
+__version__ = _version("omnimalloc")
+
+from ._allocate import allocate
+from .primitives import Allocation, Memory, Pool, System
+from .validate import validate_allocation
+from .visualize import plot_allocation
+
+__all__ = [
+    "Allocation",
+    "Memory",
+    "Pool",
+    "System",
+    "__version__",
+    "allocate",
+    "plot_allocation",
+    "validate_allocation",
+]

--- a/src/python/omnimalloc/common/__init__.py
+++ b/src/python/omnimalloc/common/__init__.py
@@ -1,8 +1,3 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-
-from .optional import require_optional as require_optional
-from .parallel import max_threads as max_threads
-from .parallel import set_max_threads as set_max_threads
-from .registry import Registered as Registered

--- a/tests/unit/analysis/test_linearize.py
+++ b/tests/unit/analysis/test_linearize.py
@@ -5,9 +5,9 @@
 import random
 
 import pytest
-from omnimalloc import try_linearize
 from omnimalloc._cpp import conflicts
 from omnimalloc.allocators.supermalloc import SupermallocAllocator
+from omnimalloc.analysis import try_linearize
 from omnimalloc.primitives import Allocation
 from omnimalloc.primitives.pool import Pool
 from omnimalloc.validate import validate_allocation

--- a/tests/unit/test_properties.py
+++ b/tests/unit/test_properties.py
@@ -9,7 +9,6 @@ from omnimalloc import (
     Allocation,
     Pool,
     allocate,
-    try_linearize,
     validate_allocation,
 )
 from omnimalloc.allocators import BaseAllocator, available_allocators
@@ -20,6 +19,7 @@ from omnimalloc.analysis import (
     conflict_graph,
     conflicts,
     placement_pressure,
+    try_linearize,
 )
 from omnimalloc.benchmark.sources import (
     ConcurrentTilingSource,


### PR DESCRIPTION
`from importlib.metadata import version` bound `omnimalloc.version` as a
public-looking name that was really stdlib's version lookup, so
`om.version("pytest")` happily reported another package's version. Import it
under a private alias.

Declare `__all__`. Without one, `help(omnimalloc)` listed no functions or
classes at all, and `import *` pulled in every submodule bound as an import
side effect.

Drop the eleven re-exports with no consumer outside the package: OmniAllocator,
try_linearize, save_allocation, load_allocation, TimePoint, AllocationKind,
IdType, max_threads, set_max_threads, conflicts, pressure. Each stays reachable
one level down, in the module that owns it, where the callers that use it
already import it from. Exporting exactly one of nineteen allocators was the
least defensible of these: `allocate` already defaults to it. `conflicts` and
`pressure` were two of the thirteen names `analysis` exports; hoisting that
pair and no other made the top level an arbitrary slice of a namespace that
reads better whole.

`common/__init__.py` re-exported four names that nothing imported; every
consumer names the leaf module. Empty it.

What survives is the hierarchy, the verb that places it, and the two functions
that check and draw the result.

---

Also fixes an unrelated Windows CI failure that predates this branch: with
`--import-mode=importlib` the rootdir is never on `sys.path`, so spawned
`ProcessPoolExecutor` workers cannot import `tests` to unpickle a test-defined
allocator variant. The worker dies mid-unpickle and takes the pool with it, which
made `test_one_failing_variant_does_not_sink_the_parallel_call` a race on Windows
and macOS. `pythonpath = ["."]` restores it.

