### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: pypa/cibuildwheel@v2.22
+      - uses: pypa/cibuildwheel@v4.1
       - uses: actions/upload-artifact@v4
         with:
           name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -72,14 +72,14 @@ jobs:
         # Full Python matrix on Linux, plus one job per additional platform
         # the wheels are built for (keep in sync with build.yml).
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: ubuntu-24.04-arm
-            python-version: "3.13"
+            python-version: "3.14"
           - os: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: windows-latest
-            python-version: "3.13"
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: C++",
   "Topic :: Scientific/Engineering",
   "Topic :: Software Development :: Libraries :: Python Modules",
@@ -73,7 +74,7 @@ metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
 [tool.setuptools_scm]
 
 [tool.cibuildwheel]
-build = "cp310-* cp311-* cp312-* cp313-*"
+build = "cp310-* cp311-* cp312-* cp313-* cp314-*"
 skip = "*-musllinux_*"
 # TODO(fpedd): Enable tests in the future
 # test-requires = ["pytest"]

--- a/src/python/omnimalloc/allocators/greedy.py
+++ b/src/python/omnimalloc/allocators/greedy.py
@@ -3,8 +3,7 @@
 #
 
 import logging
-import threading
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ThreadPoolExecutor
 
 from omnimalloc._cpp import first_fit_place
 from omnimalloc.analysis import conflict_degrees, placement_pressure
@@ -69,61 +68,6 @@ def order_by_start(allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...
     return tuple(sorted(allocations, key=lambda a: (a.start, -a.size)))
 
 
-def _run_variant(
-    allocator: BaseAllocator, allocations: tuple[Allocation, ...]
-) -> tuple[Allocation, ...]:
-    """Worker: flat plain-typed kwargs make every allocator picklable."""
-    return allocator.allocate(allocations)
-
-
-def _place_serially(
-    allocations: tuple[Allocation, ...], variants: tuple[BaseAllocator, ...]
-) -> list[tuple[Allocation, ...]]:
-    results = []
-    for variant in variants:
-        try:
-            results.append(variant.allocate(allocations))
-        except Exception:
-            logger.warning("Variant %s failed; skipping it", variant, exc_info=True)
-    return results
-
-
-def _pool_is_safe(workers: int) -> bool:
-    """Whether the pool is worth starting for this many workers.
-
-    It forks, and forking a process that has other threads running leaves the
-    child holding locks nobody will release: it may raise, or it may deadlock.
-    """
-    return workers > 1 and threading.active_count() == 1
-
-
-def _place_pooled(
-    allocations: tuple[Allocation, ...],
-    variants: tuple[BaseAllocator, ...],
-    workers: int,
-) -> list[tuple[Allocation, ...]] | None:
-    """Results from the process pool, or None when the fork is refused.
-
-    The backstop for a thread that starts between the check and the fork; a
-    placement is worth more than the parallelism, so the caller retries serially.
-    """
-    results = []
-    try:
-        with ProcessPoolExecutor(max_workers=workers) as pool:
-            futures = [pool.submit(_run_variant, v, allocations) for v in variants]
-            for variant, future in zip(variants, futures, strict=True):
-                try:
-                    results.append(future.result())
-                except Exception:
-                    logger.warning(
-                        "Variant %s failed; skipping it", variant, exc_info=True
-                    )
-    except (OSError, RuntimeError) as e:
-        logger.warning("Process pool unavailable (%s); placing serially", e)
-        return None
-    return results
-
-
 def allocate_parallel(
     allocations: tuple[Allocation, ...],
     variants: tuple[BaseAllocator, ...],
@@ -136,13 +80,14 @@ def allocate_parallel(
 
     workers = min(resolve_num_threads(num_threads), len(variants))
 
-    results = (
-        _place_pooled(allocations, variants, workers)
-        if _pool_is_safe(workers)
-        else None
-    )
-    if results is None:
-        results = _place_serially(allocations, variants)
+    results = []
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(v.allocate, allocations) for v in variants]
+        for variant, future in zip(variants, futures, strict=True):
+            try:
+                results.append(future.result())
+            except Exception:
+                logger.warning("Variant %s failed; skipping it", variant, exc_info=True)
 
     if not results:
         raise RuntimeError("Every allocator variant failed")

--- a/src/python/omnimalloc/common/parallel.py
+++ b/src/python/omnimalloc/common/parallel.py
@@ -13,7 +13,7 @@ from .validation import ensure_positive
 def set_max_threads(value: int | None) -> None:
     """Cap the workers this library will use, anywhere; None lifts the cap.
 
-    Covers the native kernels and the process pools alike. The kernels spawn per
+    Covers the native kernels and the worker pools alike. The kernels spawn per
     call, so without the default 8, N callers put N times the cores in flight.
     """
     if value is not None and value < 1:
@@ -41,7 +41,7 @@ def resolve_num_threads(num_threads: int | None) -> int:
     """Worker count for a parallel section; None resolves to the ceiling.
 
     An explicit count is taken as given; `None` defers to `max_threads`, so one
-    setting governs the process pools and the native kernels together.
+    setting governs the worker pools and the native kernels together.
     """
     ensure_positive(num_threads, "num_threads", allow_none=True)
     return num_threads if num_threads is not None else max_threads()

--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -10,7 +10,7 @@ import pytest
 from omnimalloc.common.directories import EXAMPLES_DIR
 
 EXAMPLE_FILES = sorted(EXAMPLES_DIR.glob("*.py"))
-TIMEOUT_SECONDS = 300  # 5 minutes
+TIMEOUT_SECONDS = 600  # 10 minutes
 
 
 @pytest.mark.parametrize("example_file", EXAMPLE_FILES, ids=lambda p: p.name)

--- a/tests/unit/allocators/test_base.py
+++ b/tests/unit/allocators/test_base.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+from concurrent.futures import ThreadPoolExecutor
+
 import pytest
 from omnimalloc.allocators import greedy
 from omnimalloc.allocators.base import BaseAllocator
@@ -54,15 +56,12 @@ def test_portfolio_never_spawns_more_workers_than_variants(
 ) -> None:
     seen = []
 
-    class Recorder:
+    class Recorder(ThreadPoolExecutor):
         def __init__(self, max_workers: int) -> None:
             seen.append(max_workers)
-            raise RuntimeError("Stop before spawning workers")
+            super().__init__(max_workers=max_workers)
 
-    # Pinned: the pool is skipped outright once any other thread is alive, and
-    # an earlier test leaving one would otherwise decide this one.
-    monkeypatch.setattr(greedy.threading, "active_count", lambda: 1)
-    monkeypatch.setattr(greedy, "ProcessPoolExecutor", Recorder)
+    monkeypatch.setattr(greedy, "ThreadPoolExecutor", Recorder)
     variants = (OmniAllocator(), OmniAllocator())
     placed = allocate_parallel(ALLOCATIONS, variants, num_threads=32)
     assert seen == [len(variants)]

--- a/tests/unit/allocators/test_greedy.py
+++ b/tests/unit/allocators/test_greedy.py
@@ -530,19 +530,3 @@ def test_greedy_by_all_from_a_threaded_caller_places_every_allocation() -> None:
     assert not [r for r in results if isinstance(r, Exception)]
     for placed in results:
         validate_allocation(placed)
-
-
-def test_a_refused_fork_falls_back_to_the_serial_path(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    def refuse(*_args: object, **_kwargs: object) -> None:
-        raise RuntimeError("os.fork is unsafe while filelock is changing ownership")
-
-    monkeypatch.setattr(greedy.threading, "active_count", lambda: 1)
-    monkeypatch.setattr(greedy, "ProcessPoolExecutor", refuse)
-    allocations = tuple(Allocation(id=i, size=8, start=i, end=i + 3) for i in range(16))
-    placed = GreedyByAllAllocator().allocate(allocations)
-    validate_allocation(placed)
-    assert placement_pressure(placed) == placement_pressure(
-        GreedyByAllAllocator(num_threads=1).allocate(allocations)
-    )

--- a/uv.lock
+++ b/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
     "python_full_version < '3.11'",
@@ -312,7 +313,8 @@ name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -855,7 +857,8 @@ name = "ipython"
 version = "9.16.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -1296,7 +1299,8 @@ name = "matplotlib"
 version = "3.11.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]
@@ -1688,7 +1692,8 @@ name = "numpy"
 version = "2.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/fd/89965aa4ac08c74998539fcbf24fa3540f3e15237fbeb6bcf9c908f4aade/numpy-2.5.1.tar.gz", hash = "sha256:a48a113e6afea91f5608793bafa7ef2ad481fefbda87ec5069f483de61cb9fa3", size = 20755553, upload-time = "2026-07-04T17:08:00.933Z" }
@@ -2455,7 +2460,8 @@ name = "rpds-py"
 version = "2026.6.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.13'",
+    "python_full_version >= '3.14'",
+    "python_full_version == '3.13.*'",
     "python_full_version == '3.12.*'",
     "python_full_version == '3.11.*'",
 ]


### PR DESCRIPTION
Adds 3.14 to the classifiers, the cibuildwheel targets and the CI matrix, and
moves the single-platform legs from 3.13 to 3.14 so the newest interpreter is
the one exercised on arm64, macOS and Windows. The cibuildwheel action goes to
v4.1; v2.22 predates cp314 and would silently build nothing for it.

The substantive change is allocate_parallel. 3.14 defaults multiprocessing to
forkserver on Linux, and its workers re-import the caller's __main__ instead of
inheriting it, so every call re-imported omnimalloc once per worker: the
four-variant greedy portfolio over 2k allocations costs 755 ms across four
processes against 42 ms serial. set_forkserver_preload does not help, the cost
being the main-module fixup rather than the preload list.

It runs on threads now, at 20 ms. The placement kernels release the GIL and take
their allocations by value, the invariant bindings.cpp already declares and the
concurrent torture tests already assert, so the variants scale without sharing
state. Threads need no fork, so the check that skipped the pool whenever another
thread was alive, the serial fallback behind it, and the picklability constraint
that shaped the worker indirection all go: fifty lines of machinery for a path
that is now faster and unconditional. The tradeoff is isolation, a variant dying
mid-run now taking the process with it, but under forkserver one broken worker
already failed every pending future in the pool.

The example timeout doubles to ten minutes. 05_benchmark spends its time saving
75 plots, not allocating, and that phase runs about a third slower on 3.14: it
took 211 to 244 s against the 300 s cap on the legs that passed and overran it
on three of the four 3.14 legs. Neither pool is implicated; the example measures
134 s on threads against 139 s on processes on the same 3.14 interpreter.

The extras keep their existing floors. Every release the resolver would pick on
3.14 ships cp314 wheels already, so pinning 3.14-conditional floors only forked
the lockfile.

Verified on 3.10, 3.13 and 3.14: unit suite green on each, integration suite
green on 3.14, and all five examples run there.