### PR TITLE
Fix eight defects found auditing the placement and validation paths

### DIFF
--- a/src/cpp/allocators/first_fit.cpp
+++ b/src/cpp/allocators/first_fit.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
-#include <cstring>
 #include <limits>
 #include <numeric>
 #include <stdexcept>
@@ -65,7 +64,7 @@ void sort_intervals_by_lo(std::vector<Interval>& intervals,
     shift += kDigitBits;
   }
   if (src != intervals.data()) {
-    std::memcpy(intervals.data(), src, m * sizeof(Interval));
+    std::copy_n(src, m, intervals.data());
   }
 }
 

--- a/src/python/omnimalloc/allocators/base.py
+++ b/src/python/omnimalloc/allocators/base.py
@@ -50,6 +50,7 @@ class BaseAllocator(Registered):
         if pins:
             self._ensure_pins_placeable(allocations)
         placed = self._allocate(allocations)
+        self._ensure_same_set(allocations, placed)
         self._ensure_placed(placed, pins)
         return placed
 
@@ -90,6 +91,15 @@ class BaseAllocator(Registered):
                 f"pinned allocations {pinned[first].id!r} and "
                 f"{pinned[second].id!r} already collide"
             )
+
+    def _ensure_same_set(
+        self, allocations: tuple["Allocation", ...], placed: tuple["Allocation", ...]
+    ) -> None:
+        """Refuse a dropped or padded result; ranked by peak, it would win."""
+        placed_ids = {alloc.id for alloc in placed}
+        wanted_ids = {alloc.id for alloc in allocations}
+        if len(placed) != len(allocations) or placed_ids != wanted_ids:
+            raise ValueError(f"{self.name()} returned a different allocation set")
 
     def _ensure_placed(
         self, placed: tuple["Allocation", ...], pins: dict["IdType", int | None]

--- a/src/python/omnimalloc/allocators/greedy_base.py
+++ b/src/python/omnimalloc/allocators/greedy_base.py
@@ -91,9 +91,9 @@ def allocate_parallel(
     if not allocations:
         return allocations
 
-    workers = resolve_num_threads(num_threads)
-    if num_threads is None:
-        workers = min(workers, len(variants))
+    # There is nothing for a worker beyond the last variant to do, so cap on
+    # both paths: an explicit count is a ceiling, not a demand for processes
+    workers = min(resolve_num_threads(num_threads), len(variants))
 
     # One variant dying (raised, or its worker OOM-killed) must not discard
     # the placements the others already produced, on either path

--- a/src/python/omnimalloc/allocators/supermalloc.py
+++ b/src/python/omnimalloc/allocators/supermalloc.py
@@ -173,7 +173,9 @@ class SupermallocAllocator(BaseAllocator):
             return SupermallocResult(
                 allocations=(), peak=0, lower_bound=0, proved_optimal=True
             )
-        return self._solve(allocations)
+        result = self._solve(allocations)
+        self._ensure_same_set(allocations, result.allocations)
+        return result
 
     def _allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
         return self._solve(allocations).allocations

--- a/src/python/omnimalloc/benchmark/benchmark.py
+++ b/src/python/omnimalloc/benchmark/benchmark.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class SkippedAllocator:
-    """An allocator left out of a campaign because a source outran it."""
+    """An allocator left out of a campaign, with the reason it was skipped."""
 
     source: str
     allocator: str
@@ -218,7 +218,21 @@ def run_benchmark(
             position=1,
             leave=False,
         ):
-            allocator_inst = BaseAllocator.resolve(allocator)
+            # An allocator wrapping an uninstalled library is a skip, not an
+            # abort: `available_allocators()` lists every registered name, so
+            # the default campaign would otherwise die on the first optional one
+            try:
+                allocator_inst = BaseAllocator.resolve(allocator)
+            except ImportError as error:
+                reason = str(error).splitlines()[0]
+                name = allocator if isinstance(allocator, str) else allocator.name()
+                logger.warning(f"Skipping {name} on {source_inst.label()}: {reason}")
+                skipped.append(
+                    SkippedAllocator(
+                        source=source_inst.label(), allocator=name, reason=reason
+                    )
+                )
+                continue
 
             for variant_id in tqdm(
                 variant_ids,

--- a/src/python/omnimalloc/benchmark/converters/model.py
+++ b/src/python/omnimalloc/benchmark/converters/model.py
@@ -140,8 +140,8 @@ def model_to_pools(
     model: Model,
     include_const: bool = True,
     include_io: bool = True,
-    const_inf_lifetime: bool = False,
-    io_inf_lifetime: bool = False,
+    const_inf_lifetime: bool = True,
+    io_inf_lifetime: bool = True,
 ) -> tuple[Pool, ...]:
     """Extract Pools grouped by buffer kind."""
     buffer_to_first_index, buffer_to_last_index = _compute_buffer_lifetimes(

--- a/src/python/omnimalloc/benchmark/results/visualize.py
+++ b/src/python/omnimalloc/benchmark/results/visualize.py
@@ -62,14 +62,12 @@ def _get_sorted_reports(
     allocator_data: dict[str, tuple[BenchmarkReport, ...]],
 ) -> list[BenchmarkReport]:
     reports = [r for rs in allocator_data.values() for r in rs]
-    is_categorical = any(r.is_categorical for r in reports)
-    reports.sort(
-        key=lambda r: (
-            r.variant_id
-            if is_categorical and r.variant_id is not None
-            else r.num_allocations
-        )
-    )
+    # One key type for the whole group: mixing a categorical variant_id with a
+    # numeric fallback compares str against int and raises mid-sort
+    if any(r.is_categorical for r in reports):
+        reports.sort(key=lambda r: str(r.variant_id))
+    else:
+        reports.sort(key=lambda r: r.num_allocations)
     return reports
 
 

--- a/src/python/omnimalloc/primitives/memory.py
+++ b/src/python/omnimalloc/primitives/memory.py
@@ -11,7 +11,7 @@ from omnimalloc.common.validation import ensure_non_negative
 
 from .allocation import IdType
 from .pool import Pool
-from .utils import ensure_unique_ids
+from .utils import ensure_items, ensure_unique_ids
 
 if TYPE_CHECKING:
     from omnimalloc.allocators import BaseAllocator
@@ -26,6 +26,7 @@ class Memory:
     size: int | None = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "pools", ensure_items(self.pools, Pool, "pools"))
         ensure_unique_ids(self.pools, "pool")
         if self.size is not None:
             ensure_non_negative(self.size, "size")

--- a/src/python/omnimalloc/primitives/pool.py
+++ b/src/python/omnimalloc/primitives/pool.py
@@ -26,6 +26,7 @@ class Pool:
     offset: int | None = None
 
     def __post_init__(self) -> None:
+        object.__setattr__(self, "allocations", ensure_allocations(self.allocations))
         ensure_unique_ids(self.allocations, "allocation")
         if self.offset is not None:
             ensure_non_negative(self.offset, "offset")
@@ -82,12 +83,6 @@ class Pool:
     def allocate(self, allocator: "BaseAllocator") -> "Pool":
         """Assign offsets to the unpinned allocations, preserving input order."""
         allocated = allocator.allocate(self.allocations)
-        if len(allocated) != len(self.allocations) or {a.id for a in allocated} != {
-            a.id for a in self.allocations
-        }:
-            raise ValueError(
-                f"allocator {allocator!s} returned a different allocation set"
-            )
         # Allocators may reorder internally; restore the pool's input order so
         # positions in the returned tuple keep corresponding to the request
         placed_by_id = {a.id: a for a in allocated}

--- a/src/python/omnimalloc/primitives/system.py
+++ b/src/python/omnimalloc/primitives/system.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 from .allocation import IdType
 from .memory import Memory
-from .utils import ensure_unique_ids
+from .utils import ensure_items, ensure_unique_ids
 
 
 @dataclass(frozen=True)
@@ -22,6 +22,9 @@ class System:
     memories: tuple[Memory, ...]
 
     def __post_init__(self) -> None:
+        object.__setattr__(
+            self, "memories", ensure_items(self.memories, Memory, "memories")
+        )
         ensure_unique_ids(self.memories, "memory")
 
     @property

--- a/src/python/omnimalloc/primitives/utils.py
+++ b/src/python/omnimalloc/primitives/utils.py
@@ -3,9 +3,11 @@
 #
 
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, TypeVar
 
 from .allocation import Allocation
+
+T = TypeVar("T")
 
 
 def ensure_unique_ids(entities: Sequence[Any], kind: str) -> None:
@@ -22,13 +24,18 @@ def ensure_unique_ids(entities: Sequence[Any], kind: str) -> None:
         seen[entity.id] = index
 
 
+def ensure_items(items: object, item_type: type[T], label: str) -> tuple[T, ...]:
+    """Coerce a raw sequence to a tuple, requiring every element be `item_type`."""
+    if isinstance(items, str | bytes) or not isinstance(items, Sequence):
+        raise TypeError(f"Unsupported {label} type: {type(items)!r}")
+    checked: list[T] = []
+    for item in items:
+        if not isinstance(item, item_type):
+            raise TypeError(f"Expected {item_type.__name__}, got {type(item)!r}")
+        checked.append(item)
+    return tuple(checked)
+
+
 def ensure_allocations(allocations: object) -> tuple[Allocation, ...]:
     """Coerce a raw sequence to a tuple, requiring every element be an Allocation."""
-    if isinstance(allocations, str | bytes) or not isinstance(allocations, Sequence):
-        raise TypeError(f"Unsupported entity type: {type(allocations)!r}")
-    checked: list[Allocation] = []
-    for alloc in allocations:
-        if not isinstance(alloc, Allocation):
-            raise TypeError(f"Expected Allocation, got {type(alloc)!r}")
-        checked.append(alloc)
-    return tuple(checked)
+    return ensure_items(allocations, Allocation, "entity")

--- a/src/python/omnimalloc/validate.py
+++ b/src/python/omnimalloc/validate.py
@@ -24,13 +24,19 @@ def _check_ids_across_pools(pools: tuple[Pool, ...]) -> None:
             owner[alloc.id] = pool.id
 
 
-def _check_alignment(allocations: tuple[Allocation, ...], alignment: int) -> None:
-    if alignment <= 0:
-        raise ValueError(f"alignment must be positive, got {alignment}")
+def _check_alignment(
+    allocations: tuple[Allocation, ...], alignment: int, base: int
+) -> None:
+    # Allocation offsets are pool-relative, so alignment is a property of
+    # `base + offset`: a pool sitting at an unaligned base misaligns every
+    # allocation in it, however well-aligned each offset looks on its own.
     for alloc in allocations:
-        if alloc.offset is not None and alloc.offset % alignment != 0:
+        if alloc.offset is None:
+            continue
+        address = base + alloc.offset
+        if address % alignment != 0:
             raise ValueError(
-                f"allocation {alloc.id!r} at offset {alloc.offset} is not "
+                f"allocation {alloc.id!r} at address {address} is not "
                 f"{alignment}-byte aligned"
             )
 
@@ -59,12 +65,12 @@ def _check_pool_overlaps(pools: tuple[Pool, ...]) -> None:
 
 
 def _validate_allocations(
-    allocations: tuple[Allocation, ...], alignment: int | None = None
+    allocations: tuple[Allocation, ...], alignment: int | None, base: int = 0
 ) -> None:
     ensure_unique_ids(allocations, "allocation")
     uniform_dim(allocations)
     if alignment is not None:
-        _check_alignment(allocations, alignment)
+        _check_alignment(allocations, alignment, base)
     _check_collisions(allocations)
 
 
@@ -72,7 +78,7 @@ def _validate_pools(pools: tuple[Pool, ...], alignment: int | None) -> None:
     ensure_unique_ids(pools, "pool")
     for pool in pools:
         try:
-            _validate_allocations(pool.allocations, alignment)
+            _validate_allocations(pool.allocations, alignment, pool.offset or 0)
         except ValueError as e:
             raise ValueError(f"in pool {pool.id!r}, {e}") from e
     _check_ids_across_pools(pools)
@@ -85,7 +91,7 @@ def _check_size(memory: Memory, require_capacity: bool) -> None:
             raise ValueError("no size declared")
         return
     if memory.extent > memory.size:
-        raise ValueError(f"used size {memory.extent} exceeds memory size {memory.size}")
+        raise ValueError(f"extent {memory.extent} exceeds memory size {memory.size}")
 
 
 def _validate_memories(
@@ -110,6 +116,9 @@ def validate_allocation(
     Checks unique ids, that everything is placed, that no rectangles collide, and
     that each memory fits its size. `require_capacity`/`alignment` tighten it.
     """
+    if alignment is not None and alignment <= 0:
+        raise ValueError(f"Alignment must be positive, got {alignment}")
+
     if isinstance(entity, System | Memory | Pool):
         described = f"{type(entity).__name__} {entity.id!r}"
     elif isinstance(entity, Sequence) and not isinstance(entity, str | bytes):
@@ -123,7 +132,7 @@ def validate_allocation(
         elif isinstance(entity, Memory):
             _validate_memories((entity,), require_capacity, alignment)
         elif isinstance(entity, Pool):
-            _validate_allocations(entity.allocations, alignment)
+            _validate_allocations(entity.allocations, alignment, entity.offset or 0)
         else:
             _validate_allocations(ensure_allocations(entity), alignment)
     except ValueError as e:

--- a/src/python/omnimalloc/visualize.py
+++ b/src/python/omnimalloc/visualize.py
@@ -217,11 +217,25 @@ def _select_lanes(
     return sorted(ranked[:max_lanes])
 
 
-def _get_y_limits(system: System) -> dict[Memory, tuple[int, int]]:
+def _memory_top(memory: Memory, pool_offsets: dict[Pool, int]) -> int:
+    """Highest address the drawn layout reaches, pinned pools included.
+
+    `used_size` misses a pool pinned above the sum of pool sizes and `extent`
+    refuses unplaced pools, so read the top off the offsets actually drawn.
+    """
+    return max(
+        (pool_offsets[pool] + pool.size for pool in memory.pools),
+        default=0,
+    )
+
+
+def _get_y_limits(
+    system: System, offsets: dict[Memory, dict[Pool, int]]
+) -> dict[Memory, tuple[int, int]]:
     limits: dict[Memory, tuple[int, int]] = {}
     for memory in system.memories:
         size = memory.size
-        used = memory.used_size
+        used = _memory_top(memory, offsets[memory])
 
         if size is None or used > size:
             # No declared size (or usage exceeds it), scale to 1.2x used
@@ -484,7 +498,7 @@ def _draw_panel(
         _draw_pool_background(ax, y_offset, pool.size, colors)
 
     # Draw used-size, declared-size, and extra capacity lines
-    limits: dict[str, int] = {"used": memory.used_size}
+    limits: dict[str, int] = {"used": _memory_top(memory, y_offsets)}
     if memory.size is not None:
         limits["size"] = memory.size
     for label, per_memory_capacity in capacities.items():
@@ -517,8 +531,8 @@ def _visualize_system(
     )
     axs = [axs] if len(panels) == 1 else axs
 
-    y_limits = _get_y_limits(system)
     y_offsets = _get_y_offsets(system)
+    y_limits = _get_y_limits(system, y_offsets)
 
     for ax, panel in zip(axs, panels, strict=True):
         _draw_panel(

--- a/tests/unit/allocators/test_base.py
+++ b/tests/unit/allocators/test_base.py
@@ -1,0 +1,66 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+import pytest
+from omnimalloc.allocators import greedy_base
+from omnimalloc.allocators.base import BaseAllocator
+from omnimalloc.allocators.greedy_base import allocate_parallel
+from omnimalloc.allocators.omni import OmniAllocator
+from omnimalloc.primitives import Allocation
+
+ALLOCATIONS = tuple(Allocation(id=i, size=10 + i, start=i, end=i + 3) for i in range(6))
+
+
+class TruncatingAllocator(BaseAllocator):
+    supports_vector_time = True
+
+    def _allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
+        return tuple(a.with_offset(0) for a in allocations[:1])
+
+
+class PaddingAllocator(BaseAllocator):
+    supports_vector_time = True
+
+    def _allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
+        placed = tuple(a.with_offset(0) for a in allocations)
+        return (*placed, placed[0])
+
+
+def test_allocator_dropping_allocations_is_rejected() -> None:
+    with pytest.raises(ValueError, match="returned a different allocation set"):
+        TruncatingAllocator().allocate(ALLOCATIONS)
+
+
+def test_allocator_duplicating_allocations_is_rejected() -> None:
+    with pytest.raises(ValueError, match="returned a different allocation set"):
+        PaddingAllocator().allocate(ALLOCATIONS)
+
+
+def test_a_faithful_allocator_is_accepted() -> None:
+    placed = OmniAllocator().allocate(ALLOCATIONS)
+    assert {a.id for a in placed} == {a.id for a in ALLOCATIONS}
+
+
+def test_portfolio_drops_a_truncating_variant_instead_of_preferring_it() -> None:
+    placed = allocate_parallel(
+        ALLOCATIONS, (OmniAllocator(), TruncatingAllocator()), num_threads=1
+    )
+    assert len(placed) == len(ALLOCATIONS)
+
+
+def test_portfolio_never_spawns_more_workers_than_variants(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen = []
+
+    class Recorder:
+        def __init__(self, max_workers: int) -> None:
+            seen.append(max_workers)
+            raise RuntimeError("Stop before spawning workers")
+
+    monkeypatch.setattr(greedy_base, "ProcessPoolExecutor", Recorder)
+    variants = (OmniAllocator(), OmniAllocator())
+    with pytest.raises(RuntimeError):
+        allocate_parallel(ALLOCATIONS, variants, num_threads=32)
+    assert seen == [len(variants)]

--- a/tests/unit/allocators/test_supermalloc.py
+++ b/tests/unit/allocators/test_supermalloc.py
@@ -10,6 +10,7 @@ from omnimalloc.allocators.supermalloc import (
     Heuristic,
     SortKey,
     SupermallocAllocator,
+    SupermallocResult,
 )
 from omnimalloc.analysis import placement_pressure
 from omnimalloc.primitives import Allocation, Pool
@@ -178,6 +179,20 @@ def test_solve_reports_an_empty_problem_as_optimal() -> None:
     result = SupermallocAllocator().solve(())
     assert result.allocations == ()
     assert result.proved_optimal
+
+
+def test_solve_rejects_a_partial_result(monkeypatch: pytest.MonkeyPatch) -> None:
+    allocations = tuple(Allocation(id=i, size=10, start=0, end=5) for i in range(3))
+    allocator = SupermallocAllocator()
+    partial = SupermallocResult(
+        allocations=(allocations[0].with_offset(0),),
+        peak=10,
+        lower_bound=10,
+        proved_optimal=True,
+    )
+    monkeypatch.setattr(allocator, "_solve", lambda _: partial)
+    with pytest.raises(ValueError, match="returned a different allocation set"):
+        allocator.solve(allocations)
 
 
 def test_solve_agrees_with_allocate() -> None:

--- a/tests/unit/benchmark/converters/test_model.py
+++ b/tests/unit/benchmark/converters/test_model.py
@@ -635,9 +635,9 @@ def test_model_to_system_empty_model() -> None:
     assert len(system.memories[0].pools) == 0
 
 
-def test_model_to_pools_skips_unreferenced_buffers() -> None:
+def test_model_to_pools_skips_unreferenced_workspace_buffers() -> None:
     used = _buf("used")
-    unused = _buf("unused", AllocationKind.INPUT)
+    unused = _buf("unused")
     op = Op(id=0, outputs={used})
     model = Model(id=0, ops={0: op}, buffers={"used": used, "unused": unused})
 
@@ -645,6 +645,23 @@ def test_model_to_pools_skips_unreferenced_buffers() -> None:
 
     allocation_ids = {a.id for pool in pools for a in pool.allocations}
     assert allocation_ids == {"used"}
+
+
+def test_model_to_pools_keeps_unreferenced_io_and_constant_buffers() -> None:
+    used = _buf("used")
+    spare_input = _buf("spare_input", AllocationKind.INPUT)
+    spare_const = _buf("spare_const", AllocationKind.CONSTANT)
+    op = Op(id=0, outputs={used})
+    model = Model(
+        id=0,
+        ops={0: op},
+        buffers={"used": used, "spare_input": spare_input, "spare_const": spare_const},
+    )
+
+    pools = model_to_pools(model)
+
+    allocation_ids = {a.id for pool in pools for a in pool.allocations}
+    assert allocation_ids == {"used", "spare_input", "spare_const"}
 
 
 def test_model_to_allocations_skips_unreferenced_buffers() -> None:

--- a/tests/unit/benchmark/results/test_visualize.py
+++ b/tests/unit/benchmark/results/test_visualize.py
@@ -13,9 +13,28 @@ from omnimalloc.benchmark.results.visualize import (
     _canonicalize_artifact,
     _format_metadata,
     _get_allocator_color,
+    _get_sorted_reports,
     plot_benchmark,
 )
 from omnimalloc.benchmark.sources.generator import RandomSource
+
+
+def _result(size: int = 10) -> BenchmarkResult:
+    source = RandomSource(num_allocations=size, seed=42)
+    allocator = GreedyAllocator()
+    return BenchmarkResult(
+        id=0,
+        allocator=allocator,
+        source=source,
+        entity=allocate(source.get_pool(), allocator),
+        duration=0.5,
+    )
+
+
+def _report(report_id: str, variant_id: object, size: int = 10) -> BenchmarkReport:
+    return BenchmarkReport(
+        id=report_id, results=(_result(size),), variant_id=variant_id
+    )
 
 
 def test_get_allocator_color() -> None:
@@ -48,18 +67,7 @@ def test_format_metadata() -> None:
 
 def test_canonicalize_artifact() -> None:
     """Test artifact canonicalization to campaign."""
-    source = RandomSource(num_allocations=10, seed=42)
-    allocator = GreedyAllocator()
-    pool = source.get_pool()
-    allocated_pool = allocate(pool, allocator)
-
-    result = BenchmarkResult(
-        id=0,
-        allocator=allocator,
-        source=source,
-        entity=allocated_pool,
-        duration=0.5,
-    )
+    result = _result()
 
     campaign_from_result = _canonicalize_artifact(result)
     assert isinstance(campaign_from_result, BenchmarkCampaign)
@@ -83,16 +91,28 @@ def test_plot_benchmark_without_path_shows_figure(
 ) -> None:
     import matplotlib.pyplot as plt
 
-    source = RandomSource(num_allocations=10, seed=42)
-    allocator = GreedyAllocator()
-    result = BenchmarkResult(
-        id=0,
-        allocator=allocator,
-        source=source,
-        entity=allocate(source.get_pool(), allocator),
-        duration=0.5,
-    )
     shown = []
     monkeypatch.setattr(plt, "show", lambda: shown.append(True))
-    plot_benchmark(result)
+    plot_benchmark(_result())
     assert shown == [True]
+
+
+def test_sorted_reports_handles_mixed_variant_id_types() -> None:
+    mixed = {"a": (_report("r0", "small"), _report("r1", 100), _report("r2", None))}
+    assert len(_get_sorted_reports(mixed)) == 3
+
+
+def test_sorted_reports_orders_numeric_variants_by_size() -> None:
+    numeric = {
+        "a": (
+            _report("r0", 30, size=30),
+            _report("r1", 10, size=10),
+            _report("r2", 20, size=20),
+        )
+    }
+    assert [r.variant_id for r in _get_sorted_reports(numeric)] == [10, 20, 30]
+
+
+def test_sorted_reports_orders_categorical_variants_by_name() -> None:
+    categorical = {"a": (_report("r0", "c"), _report("r1", "a"), _report("r2", "b"))}
+    assert [r.variant_id for r in _get_sorted_reports(categorical)] == ["a", "b", "c"]

--- a/tests/unit/primitives/test_memory.py
+++ b/tests/unit/primitives/test_memory.py
@@ -284,3 +284,14 @@ def test_allocate_empty_pool_takes_a_base() -> None:
     memory = Memory(id="m", pools=(empty, used)).allocate(NaiveAllocator())
     assert [pool.offset for pool in memory.pools] == [0, 0]
     assert memory.extent == 10
+
+
+def test_memory_coerces_a_list_of_pools_to_a_tuple() -> None:
+    memory = Memory(id="m", pools=[Pool(id="p", allocations=())])
+    assert isinstance(memory.pools, tuple)
+    assert hash(memory)
+
+
+def test_memory_rejects_non_pool_members() -> None:
+    with pytest.raises(TypeError, match="Expected Pool"):
+        Memory(id="m", pools=[1])

--- a/tests/unit/primitives/test_pool.py
+++ b/tests/unit/primitives/test_pool.py
@@ -387,3 +387,14 @@ def test_allocate_preserves_allocation_order() -> None:
     assert tuple(a.size for a in allocated.allocations) == tuple(
         a.size for a in allocations
     )
+
+
+def test_pool_coerces_a_list_of_allocations_to_a_tuple() -> None:
+    pool = Pool(id="p", allocations=[Allocation(id=1, size=10, start=0, end=5)])
+    assert isinstance(pool.allocations, tuple)
+    assert hash(pool)
+
+
+def test_pool_rejects_non_allocation_members() -> None:
+    with pytest.raises(TypeError, match="Expected Allocation"):
+        Pool(id="p", allocations=[1, 2])

--- a/tests/unit/primitives/test_system.py
+++ b/tests/unit/primitives/test_system.py
@@ -206,3 +206,14 @@ def test_allocate_with_allocator() -> None:
     assert allocated_system.id == system.id
     assert len(allocated_system.memories) == 2
     assert system.is_allocated is False
+
+
+def test_system_coerces_a_list_of_memories_to_a_tuple() -> None:
+    system = System(id="s", memories=[Memory(id="m", pools=())])
+    assert isinstance(system.memories, tuple)
+    assert hash(system)
+
+
+def test_system_rejects_non_memory_members() -> None:
+    with pytest.raises(TypeError, match="Expected Memory"):
+        System(id="s", memories=[1])

--- a/tests/unit/test_validate.py
+++ b/tests/unit/test_validate.py
@@ -355,7 +355,7 @@ def test_validate_rejects_a_misaligned_offset() -> None:
 
 def test_validate_rejects_a_non_positive_alignment() -> None:
     allocations = (Allocation(id=1, size=10, start=0, end=5, offset=0),)
-    with pytest.raises(ValueError, match="alignment must be positive"):
+    with pytest.raises(ValueError, match="Alignment must be positive"):
         validate_allocation(allocations, alignment=0)
 
 
@@ -368,6 +368,34 @@ def test_validate_checks_alignment_inside_a_system() -> None:
     system = System(id="s", memories=(Memory(id="m", pools=(pool,)),))
     with pytest.raises(ValueError, match="not 16-byte aligned"):
         validate_allocation(system, alignment=16)
+
+
+def test_validate_alignment_counts_the_pool_base() -> None:
+    pool = Pool(
+        id="p",
+        allocations=(Allocation(id=1, size=10, start=0, end=5, offset=0),),
+        offset=3,
+    )
+    with pytest.raises(ValueError, match="address 3 is not 8-byte aligned"):
+        validate_allocation(Memory(id="m", pools=(pool,)), alignment=8)
+
+
+def test_validate_alignment_accepts_an_aligned_pool_base() -> None:
+    pool = Pool(
+        id="p",
+        allocations=(Allocation(id=1, size=10, start=0, end=5, offset=0),),
+        offset=8,
+    )
+    validate_allocation(Memory(id="m", pools=(pool,)), alignment=8)
+
+
+def test_validate_alignment_counts_the_base_of_a_standalone_pool() -> None:
+    pool = Pool(
+        id="p",
+        allocations=(Allocation(id=1, size=10, start=0, end=5, offset=4),),
+        offset=4,
+    )
+    validate_allocation(pool, alignment=8)
 
 
 def test_validate_accepts_a_memory_that_declares_no_size() -> None:

--- a/tests/unit/test_visualize.py
+++ b/tests/unit/test_visualize.py
@@ -13,6 +13,8 @@ from omnimalloc.visualize import (
     _conflict_pairs,
     _conflict_visibility,
     _format_bytes,
+    _get_y_limits,
+    _get_y_offsets,
     _lane_panels,
     _panel_extents,
     _projection_panels,
@@ -542,3 +544,33 @@ def test_panel_projection_never_shows_false_conflicts(artifacts_dir: Path) -> No
     output_path = artifacts_dir / "test_panel_soundness.pdf"
     plot_allocation(memory, output_path)
     assert output_path.exists()
+
+
+def test_y_limits_cover_a_pool_pinned_above_the_sum_of_pool_sizes() -> None:
+    high = Pool(
+        id="high",
+        allocations=(Allocation(id=1, size=10, start=0, end=5, offset=0),),
+        offset=1000,
+    )
+    low = Pool(
+        id="low",
+        allocations=(Allocation(id=2, size=10, start=0, end=5, offset=0),),
+        offset=0,
+    )
+    memory = Memory(id="m", pools=(high, low))
+    system = System(id="s", memories=(memory,))
+    _, upper = _get_y_limits(system, _get_y_offsets(system))[memory]
+    assert upper >= 1010
+
+
+def test_y_limits_stack_unplaced_pools_from_zero() -> None:
+    first = Pool(
+        id="a", allocations=(Allocation(id=1, size=10, start=0, end=5, offset=0),)
+    )
+    second = Pool(
+        id="b", allocations=(Allocation(id=2, size=20, start=0, end=5, offset=0),)
+    )
+    memory = Memory(id="m", pools=(first, second))
+    system = System(id="s", memories=(memory,))
+    _, upper = _get_y_limits(system, _get_y_offsets(system))[memory]
+    assert upper >= 30


### PR DESCRIPTION
`BaseAllocator.allocate` never checked that `_allocate` returned the set it was
given. Only `Pool.allocate` did, and the portfolio path bypasses it. Since
`allocate_parallel` ranks variants by `max(offset + size)`, a variant that
dropped allocations scored the lowest peak and always won, so a partial
placement silently beat every correct one. Check the set in `_ensure_same_set`,
where every caller goes through, and drop the now-unreachable copy in
`Pool.allocate`. `SupermallocAllocator.solve` sidesteps `allocate` to keep the
search's verdict, so it runs the same check on its own result.

Alignment validation read `alloc.offset % alignment`, but allocation offsets are
pool-relative. A pool based at 3 holding an allocation at offset 0 passed
`alignment=8` while sitting at address 3. Check `base + offset`, and hoist the
`alignment > 0` guard to the entry point instead of re-running it per pool.

`plot_allocation` sized the y-axis from `Memory.used_size`, the sum of pool
sizes, which a pool pinned above that sum exceeds entirely: such a pool was
drawn outside the axes and silently vanished. `Memory.extent` is the right
quantity but refuses unplaced pools, which the plotter lays out itself, so read
the top off the offsets actually being drawn.

`run_benchmark()` defaults to `available_allocators()`, which lists every
registered name including those wrapping uninstalled optional libraries, and
resolved them outside any handler. The documented zero-argument call died with
ImportError. Record a SkippedAllocator, as an unsupported allocator already does.

Pool, Memory and System annotate tuple fields, validate ids, and are frozen, but
never checked the container: a list survived into the field, left the "frozen"
object mutable, and surfaced much later as `unhashable type: 'list'` from inside
the plotter. Coerce through a shared `ensure_items`.

`allocate_parallel` capped workers at the variant count only when `num_threads`
was None, so an explicit 32 spawned 32 processes for 7 variants.

`_get_sorted_reports` derived `is_categorical` from the whole group but keyed
per report, comparing str against int mid-sort on a mixed campaign.

`sort_intervals_by_lo` memcpy'd `std::pair<int64_t, int64_t>`, which has no
trivial copy-assignment; `std::copy_n` compiles to the same thing without the
-Wclass-memaccess diagnostic.

