### PR TITLE
Collapse the six hand-rolled duplicate-id checks into one helper

### DIFF
--- a/src/python/omnimalloc/allocators/base.py
+++ b/src/python/omnimalloc/allocators/base.py
@@ -41,7 +41,7 @@ class BaseAllocator(Registered):
         self, allocations: tuple["Allocation", ...]
     ) -> tuple["Allocation", ...]:
         """Validate shared preconditions, then run the allocator."""
-        ensure_unique_ids(allocations)
+        ensure_unique_ids(allocations, "allocation")
         uniform_dim(allocations)
         self.ensure_supported(allocations)
         if not allocations:

--- a/src/python/omnimalloc/allocators/supermalloc.py
+++ b/src/python/omnimalloc/allocators/supermalloc.py
@@ -167,7 +167,7 @@ class SupermallocAllocator(BaseAllocator):
         `allocate` returns the placement alone, which cannot say whether the
         search proved optimality or merely ran out of budget.
         """
-        ensure_unique_ids(allocations)
+        ensure_unique_ids(allocations, "allocation")
         self.ensure_supported(allocations)
         if not allocations:
             return SupermallocResult(

--- a/src/python/omnimalloc/analysis/_conflicts.py
+++ b/src/python/omnimalloc/analysis/_conflicts.py
@@ -26,7 +26,7 @@ def conflicts(
     past `work_budget`, whose tight default reflects the map, not the sweep.
     """
     ensure_valid_budget(work_budget)
-    ensure_unique_ids(allocations)
+    ensure_unique_ids(allocations, "allocation")
     return _conflicts(allocations, work_budget)
 
 

--- a/src/python/omnimalloc/analysis/_pressure.py
+++ b/src/python/omnimalloc/analysis/_pressure.py
@@ -78,7 +78,7 @@ def antichain_pressure_per_allocation(
     max entry equals `antichain_pressure`. Raises past `work_budget`.
     """
     ensure_valid_budget(work_budget)
-    ensure_unique_ids(allocations)
+    ensure_unique_ids(allocations, "allocation")
     peaks = _antichain_pressure_per_allocation(allocations, work_budget)
     return _keyed_by_id(allocations, peaks)
 
@@ -92,7 +92,7 @@ def closure_pressure_per_allocation(
     entry equals `closure_pressure`. Raises past `closure_cap`.
     """
     ensure_valid_budget(closure_cap, name="closure_cap")
-    ensure_unique_ids(allocations)
+    ensure_unique_ids(allocations, "allocation")
     peaks = _closure_pressure_per_allocation(allocations, closure_cap)
     return _keyed_by_id(allocations, peaks)
 
@@ -106,7 +106,7 @@ def placement_pressure_per_allocation(
     and its conflict neighbors, whose max entry equals `placement_pressure`.
     """
     ensure_valid_budget(work_budget)
-    ensure_unique_ids(allocations)
+    ensure_unique_ids(allocations, "allocation")
     peaks = _placement_pressure_per_allocation(allocations, work_budget)
     return _keyed_by_id(allocations, peaks)
 

--- a/src/python/omnimalloc/benchmark/results/campaign.py
+++ b/src/python/omnimalloc/benchmark/results/campaign.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from omnimalloc.primitives import IdType
+from omnimalloc.primitives.utils import ensure_unique_ids
 
 from .report import BenchmarkReport
 from .utils import get_environment_metadata
@@ -23,8 +24,7 @@ class BenchmarkCampaign:
     def __post_init__(self) -> None:
         if not self.reports:
             raise ValueError("BenchmarkCampaign must contain at least one report")
-        if len({r.id for r in self.reports}) != len(self.reports):
-            raise ValueError("report ids must be unique")
+        ensure_unique_ids(self.reports, "report")
 
     @property
     def num_reports(self) -> int:

--- a/src/python/omnimalloc/benchmark/results/report.py
+++ b/src/python/omnimalloc/benchmark/results/report.py
@@ -8,6 +8,7 @@ from statistics import mean, median, stdev
 from omnimalloc.allocators import BaseAllocator
 from omnimalloc.benchmark.sources import BaseSource
 from omnimalloc.primitives import IdType
+from omnimalloc.primitives.utils import ensure_unique_ids
 
 from .result import BenchmarkResult
 from .utils import source_label
@@ -32,8 +33,7 @@ class BenchmarkReport:
         if not self.results:
             raise ValueError("BenchmarkReport must contain at least one result")
 
-        if len({r.id for r in self.results}) != len(self.results):
-            raise ValueError("result ids must be unique")
+        ensure_unique_ids(self.results, "result")
 
         num_allocs = {r.num_allocations for r in self.results}
         if len(num_allocs) > 1:

--- a/src/python/omnimalloc/primitives/memory.py
+++ b/src/python/omnimalloc/primitives/memory.py
@@ -11,6 +11,7 @@ from omnimalloc.common.validation import ensure_non_negative
 
 from .allocation import IdType
 from .pool import Pool
+from .utils import ensure_unique_ids
 
 if TYPE_CHECKING:
     from omnimalloc.allocators import BaseAllocator
@@ -25,8 +26,7 @@ class Memory:
     size: int | None = None
 
     def __post_init__(self) -> None:
-        if len({pool.id for pool in self.pools}) != len(self.pools):
-            raise ValueError("pool ids must be unique")
+        ensure_unique_ids(self.pools, "pool")
         if self.size is not None:
             ensure_non_negative(self.size, "size")
 

--- a/src/python/omnimalloc/primitives/pool.py
+++ b/src/python/omnimalloc/primitives/pool.py
@@ -26,7 +26,7 @@ class Pool:
     offset: int | None = None
 
     def __post_init__(self) -> None:
-        ensure_unique_ids(self.allocations)
+        ensure_unique_ids(self.allocations, "allocation")
         if self.offset is not None:
             ensure_non_negative(self.offset, "offset")
 

--- a/src/python/omnimalloc/primitives/system.py
+++ b/src/python/omnimalloc/primitives/system.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
 
 from .allocation import IdType
 from .memory import Memory
+from .utils import ensure_unique_ids
 
 
 @dataclass(frozen=True)
@@ -21,8 +22,7 @@ class System:
     memories: tuple[Memory, ...]
 
     def __post_init__(self) -> None:
-        if len({memory.id for memory in self.memories}) != len(self.memories):
-            raise ValueError("memory ids must be unique")
+        ensure_unique_ids(self.memories, "memory")
 
     @property
     def is_allocated(self) -> bool:

--- a/src/python/omnimalloc/primitives/utils.py
+++ b/src/python/omnimalloc/primitives/utils.py
@@ -3,14 +3,26 @@
 #
 
 from collections.abc import Sequence
+from typing import Protocol
 
-from .allocation import Allocation
+from .allocation import Allocation, IdType
 
 
-def ensure_unique_ids(allocations: Sequence[Allocation]) -> None:
-    """Raise if any allocation id repeats; id-keyed placement assumes uniqueness."""
-    if len({alloc.id for alloc in allocations}) != len(allocations):
-        raise ValueError("allocation ids must be unique")
+class HasId(Protocol):
+    @property
+    def id(self) -> IdType: ...
+
+
+def ensure_unique_ids(entities: Sequence[HasId], kind: str) -> None:
+    """Raise if any id repeats; id-keyed placement assumes uniqueness."""
+    seen: dict[IdType, int] = {}
+    for index, entity in enumerate(entities):
+        if entity.id in seen:
+            raise ValueError(
+                f"{kind} ids must be unique: duplicate id {entity.id!r} "
+                f"at indices {seen[entity.id]} and {index}"
+            )
+        seen[entity.id] = index
 
 
 def ensure_allocations(allocations: object) -> tuple[Allocation, ...]:

--- a/src/python/omnimalloc/primitives/utils.py
+++ b/src/python/omnimalloc/primitives/utils.py
@@ -3,20 +3,17 @@
 #
 
 from collections.abc import Sequence
-from typing import Protocol
+from typing import Any
 
-from .allocation import Allocation, IdType
-
-
-class HasId(Protocol):
-    @property
-    def id(self) -> IdType: ...
+from .allocation import Allocation
 
 
-def ensure_unique_ids(entities: Sequence[HasId], kind: str) -> None:
+def ensure_unique_ids(entities: Sequence[Any], kind: str) -> None:
     """Raise if any id repeats; id-keyed placement assumes uniqueness."""
-    seen: dict[IdType, int] = {}
+    seen: dict[Any, int] = {}
     for index, entity in enumerate(entities):
+        if not hasattr(entity, "id"):
+            raise TypeError(f"Expected an entity with an id, got {type(entity)!r}")
         if entity.id in seen:
             raise ValueError(
                 f"{kind} ids must be unique: duplicate id {entity.id!r} "

--- a/src/python/omnimalloc/validate.py
+++ b/src/python/omnimalloc/validate.py
@@ -8,17 +8,7 @@ from omnimalloc._cpp import find_collision as _find_collision
 
 from .analysis.clock import uniform_dim
 from .primitives import Allocation, IdType, Memory, Pool, System
-from .primitives.utils import ensure_allocations
-
-
-def _check_unique_ids(entities: tuple[Memory | Pool | Allocation, ...]) -> None:
-    seen: dict[IdType, int] = {}
-    for idx, entity in enumerate(entities):
-        if entity.id in seen:
-            raise ValueError(
-                f"duplicate id {entity.id!r} at indices {seen[entity.id]} and {idx}"
-            )
-        seen[entity.id] = idx
+from .primitives.utils import ensure_allocations, ensure_unique_ids
 
 
 def _check_ids_across_pools(pools: tuple[Pool, ...]) -> None:
@@ -71,7 +61,7 @@ def _check_pool_overlaps(pools: tuple[Pool, ...]) -> None:
 def _validate_allocations(
     allocations: tuple[Allocation, ...], alignment: int | None = None
 ) -> None:
-    _check_unique_ids(allocations)
+    ensure_unique_ids(allocations, "allocation")
     uniform_dim(allocations)
     if alignment is not None:
         _check_alignment(allocations, alignment)
@@ -79,7 +69,7 @@ def _validate_allocations(
 
 
 def _validate_pools(pools: tuple[Pool, ...], alignment: int | None) -> None:
-    _check_unique_ids(pools)
+    ensure_unique_ids(pools, "pool")
     for pool in pools:
         try:
             _validate_allocations(pool.allocations, alignment)
@@ -101,7 +91,7 @@ def _check_size(memory: Memory, require_capacity: bool) -> None:
 def _validate_memories(
     memories: tuple[Memory, ...], require_capacity: bool, alignment: int | None
 ) -> None:
-    _check_unique_ids(memories)
+    ensure_unique_ids(memories, "memory")
     for memory in memories:
         try:
             _validate_pools(memory.pools, alignment)

--- a/tests/unit/primitives/test_utils.py
+++ b/tests/unit/primitives/test_utils.py
@@ -35,6 +35,13 @@ def test_ensure_unique_ids_reports_kind_id_and_indices() -> None:
         ensure_unique_ids(pools, "pool")
 
 
+def test_ensure_unique_ids_rejects_entities_without_an_id() -> None:
+    with pytest.raises(TypeError, match="Expected an entity with an id"):
+        ensure_unique_ids(
+            (Allocation(id=1, size=8, start=0, end=4), object()), "allocation"
+        )
+
+
 def test_ensure_unique_ids_reports_first_duplicate_of_several() -> None:
     allocations = (
         Allocation(id=1, size=8, start=0, end=4),

--- a/tests/unit/primitives/test_utils.py
+++ b/tests/unit/primitives/test_utils.py
@@ -3,7 +3,7 @@
 #
 
 import pytest
-from omnimalloc.primitives import Allocation
+from omnimalloc.primitives import Allocation, Pool
 from omnimalloc.primitives.utils import ensure_unique_ids
 
 
@@ -12,7 +12,11 @@ def test_ensure_unique_ids_accepts_distinct() -> None:
         Allocation(id=1, size=8, start=0, end=4),
         Allocation(id=2, size=8, start=0, end=4),
     )
-    ensure_unique_ids(allocations)
+    ensure_unique_ids(allocations, "allocation")
+
+
+def test_ensure_unique_ids_accepts_empty() -> None:
+    ensure_unique_ids((), "allocation")
 
 
 def test_ensure_unique_ids_rejects_duplicates() -> None:
@@ -20,5 +24,23 @@ def test_ensure_unique_ids_rejects_duplicates() -> None:
         Allocation(id=1, size=8, start=0, end=4),
         Allocation(id=1, size=16, start=2, end=6),
     )
-    with pytest.raises(ValueError, match="unique"):
-        ensure_unique_ids(allocations)
+    with pytest.raises(ValueError, match="allocation ids must be unique"):
+        ensure_unique_ids(allocations, "allocation")
+
+
+def test_ensure_unique_ids_reports_kind_id_and_indices() -> None:
+    pools = (Pool(id="a", allocations=()), Pool(id="a", allocations=()))
+    expected = r"pool ids must be unique: duplicate id 'a' at indices 0 and 1"
+    with pytest.raises(ValueError, match=expected):
+        ensure_unique_ids(pools, "pool")
+
+
+def test_ensure_unique_ids_reports_first_duplicate_of_several() -> None:
+    allocations = (
+        Allocation(id=1, size=8, start=0, end=4),
+        Allocation(id=2, size=8, start=0, end=4),
+        Allocation(id=2, size=8, start=0, end=4),
+        Allocation(id=1, size=8, start=0, end=4),
+    )
+    with pytest.raises(ValueError, match=r"duplicate id 2 at indices 1 and 2"):
+        ensure_unique_ids(allocations, "allocation")


### PR DESCRIPTION
`ensure_unique_ids` existed in `primitives/utils.py` but only reported that
some allocation id repeated; `validate.py` carried a second, better
implementation naming the offending id and both indices; `Memory`, `System`,
`BenchmarkReport` and `BenchmarkCampaign` each open-coded a set-length
compare. Six variants of one check, with the weakest message on the path
users hit first.

Keep the diagnostic implementation, generalize it over a `HasId` protocol so
it serves allocations, pools, memories and benchmark results alike, and route
every site through it. The `kind` noun stays an explicit argument rather than
being derived from the type, which would render `BenchmarkResult` as
"benchmarkresult".

The message splices the detail after the existing "<kind> ids must be unique"
prefix, so the wording every caller and test already matches is preserved
while Pool/Memory/System constructors gain the id and indices they never
reported. `_check_ids_across_pools` is left alone: despite the similar name
it answers a different question and names the two owning pools.
