### PR TITLE
Make the Python matrix select the interpreter it names

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -65,6 +65,7 @@ jobs:
     # Force matplotlib's non-interactive backend; runners lack a working Tcl/Tk.
     env:
       MPLBACKEND: Agg
+      UV_PYTHON: ${{ matrix.python-version }} # outranks .python-version, which pins 3.10
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
`.python-version` is tracked and pins 3.10, so `uv sync` resolved every test job
to it. `uv python install ${{ matrix.python-version }}` downloaded 3.13 and
nothing ever selected it: the 3.11, 3.12 and 3.13 jobs each logged `Using
CPython 3.10.20` and ran the same interpreter as the 3.10 job. Four Linux jobs
that differed only in their label, and three of the four versions the wheels
ship for that no test had ever imported.

`UV_PYTHON` outranks the file and reaches `uv sync`, `uv pip install` and
`uv run` from one place. The suite already passes on 3.11, 3.12 and 3.13
unchanged; this only lets CI say so.

Verified per job on the run before this change, reading the pytest header rather
than the matrix label:

```
ubuntu-latest, 3.10     => Python 3.10.20
ubuntu-latest, 3.11     => Python 3.10.20
ubuntu-latest, 3.12     => Python 3.10.20
ubuntu-latest, 3.13     => Python 3.10.20
ubuntu-24.04-arm, 3.13  => Python 3.10.20
macos-latest, 3.13      => Python 3.10.20
windows-latest, 3.13    => Python 3.10.11
```

Locally, `1314 passed, 9 skipped` on each of 3.11, 3.12 and 3.13.

`cibuildwheel` still builds cp310-cp313 wheels that nothing imports; its
`test-command` remains commented out in `pyproject.toml`. Left alone here.
