### PR TITLE
Resolve the optional minimalloc import through a local stub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.ty.environment]
 python-version = "3.10"
+extra-paths = ["stubs"]
 
 [tool.ty.src]
 exclude = ["tests/", "**/*.pyi"]

--- a/scripts/generate_readme_assets.py
+++ b/scripts/generate_readme_assets.py
@@ -200,7 +200,7 @@ def _pip_install(spec: str) -> None:
 def _ensure_minimalloc() -> None:
     """Install Google's minimalloc on demand (no PyPI wheel)."""
     try:
-        import minimalloc  # type: ignore  # noqa: F401
+        import minimalloc  # noqa: F401
     except ImportError:
         print(f"minimalloc not installed, installing from {MINIMALLOC_URL} ...")
         _pip_install(MINIMALLOC_URL)

--- a/src/python/omnimalloc/allocators/minimalloc.py
+++ b/src/python/omnimalloc/allocators/minimalloc.py
@@ -13,7 +13,7 @@ from omnimalloc.primitives import Allocation
 from .base import BaseAllocator
 
 try:
-    import minimalloc as mm  # type: ignore
+    import minimalloc as mm
 except ImportError:
     mm = cast("Any", None)
 
@@ -26,7 +26,7 @@ def _require_minimalloc() -> None:
     if mm is not None:
         return
     try:
-        import minimalloc  # type: ignore
+        import minimalloc
     except ImportError:
         # TODO(fpedd): Make minimalloc more easily installable via PyPI
         raise ImportError(
@@ -37,6 +37,9 @@ def _require_minimalloc() -> None:
 
 
 def _to_buffer(allocation: Allocation) -> "mm.Buffer":
+    # ensure_supported already rejected vector clocks; narrow the union for ty
+    assert isinstance(allocation.start, int)
+    assert isinstance(allocation.end, int)
     return mm.Buffer(
         id=str(allocation.id),
         size=allocation.size,

--- a/stubs/minimalloc.pyi
+++ b/stubs/minimalloc.pyi
@@ -1,0 +1,33 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+class Lifespan:
+    lower: int
+    upper: int
+    def __init__(self, lower: int = ..., upper: int = ...) -> None: ...
+
+class Buffer:
+    id: str
+    size: int
+    lifespan: Lifespan
+    def __init__(
+        self, id: str = ..., size: int = ..., lifespan: Lifespan = ...
+    ) -> None: ...
+
+class Problem:
+    buffers: list[Buffer]
+    capacity: int
+    def __init__(self, buffers: list[Buffer] = ...) -> None: ...
+
+class SolverParams:
+    timeout: int
+    minimize_capacity: bool
+    def __init__(self) -> None: ...
+
+class Solution:
+    offsets: list[int]
+
+class Solver:
+    def __init__(self, params: SolverParams) -> None: ...
+    def solve(self, problem: Problem) -> Solution | None: ...


### PR DESCRIPTION
The nightly fresh-deps job is the only ty environment with minimalloc
installed, so the blanket type: ignore comments guarding its import
were required everywhere else yet flagged unused-type-ignore-comment
there, and ty fails on warnings. No single suppression can satisfy
both environments.

Instead of ignoring the rule, add stubs/minimalloc.pyi covering the
small API surface the wrapper uses and point ty at it via
environment.extra-paths. The import now resolves identically whether
or not the package is installed, so all three suppression comments go
away and the wrapper is type checked against a real signature for the
first time. That surfaced one gap: Allocation bounds are typed as
int | tuple[int, ...], so _to_buffer narrows them with asserts, safe
because ensure_supported rejects vector clocks before _allocate and
one element tuples normalize to int on construction.

Verified in both environments: ty check, ruff, and the unit suite pass
without minimalloc; with it installed, ty check passes, all 29
minimalloc tests pass, and an end to end placement works.
