### PR TITLE
Ignore ty's unused-type-ignore-comment rule

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,10 @@ log_cli_date_format = "%Y-%m-%d %H:%M:%S"
 
 [tool.ty]
 
+[tool.ty.rules]
+# Ignores guarding optional imports are needed without the dep, unused with it
+unused-type-ignore-comment = "ignore"
+
 [tool.ty.environment]
 python-version = "3.10"
 


### PR DESCRIPTION
The blanket type: ignore comments guarding the optional minimalloc
imports are required wherever the package is absent (local setups and
the regular CI jobs) but flagged as unused in the nightly fresh-deps
job, the only ty environment that installs minimalloc, and ty fails
on warnings. No single comment can satisfy both environments, so
disable the rule; whether a suppression is used simply depends on
which optional dependencies are installed.

Verified with minimalloc installed (the fresh-deps scenario) and
without: ty check passes in both.
