### PR TITLE
Skip Hugging Face tests when the Hub rate limits

### DIFF
--- a/tests/unit/benchmark/sources/test_huggingface.py
+++ b/tests/unit/benchmark/sources/test_huggingface.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import functools
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -15,6 +17,22 @@ pytestmark = pytest.mark.skipif(
     not (HAS_ONNX and HAS_HUGGINGFACE_HUB),
     reason="onnx and huggingface-hub not installed",
 )
+
+
+def skip_when_rate_limited(test: Callable[..., None]) -> Callable[..., None]:
+    @functools.wraps(test)
+    def wrapper(*args: object, **kwargs: object) -> None:
+        # Local import so collection works without huggingface_hub installed
+        from huggingface_hub.errors import HfHubHTTPError
+
+        try:
+            test(*args, **kwargs)
+        except HfHubHTTPError as error:
+            if error.response.status_code == 429:
+                pytest.skip("Hugging Face Hub rate limited the request")
+            raise
+
+    return wrapper
 
 
 def test_huggingface_source_creation() -> None:
@@ -34,6 +52,7 @@ def test_huggingface_source_creation_with_params(artifacts_dir: Path) -> None:
     assert source.output_dir == str(artifacts_dir)
 
 
+@skip_when_rate_limited
 def test_huggingface_source_get_allocations_single_model(artifacts_dir: Path) -> None:
     """Test downloading and extracting allocations from a single model.
 
@@ -50,6 +69,7 @@ def test_huggingface_source_get_allocations_single_model(artifacts_dir: Path) ->
     assert all(hasattr(alloc, "end") for alloc in allocations)
 
 
+@skip_when_rate_limited
 def test_huggingface_source_get_allocations_with_count(artifacts_dir: Path) -> None:
     """Test getting a limited number of allocations."""
     source = HuggingfaceSource(num_models=1, output_dir=str(artifacts_dir))
@@ -59,6 +79,7 @@ def test_huggingface_source_get_allocations_with_count(artifacts_dir: Path) -> N
     assert len(allocations) <= 5
 
 
+@skip_when_rate_limited
 def test_huggingface_source_get_allocations_with_skip(artifacts_dir: Path) -> None:
     """Test skipping allocations."""
     source = HuggingfaceSource(num_models=1, output_dir=str(artifacts_dir))
@@ -71,6 +92,7 @@ def test_huggingface_source_get_allocations_with_skip(artifacts_dir: Path) -> No
         assert skipped_allocations[0] == all_allocations[2]
 
 
+@skip_when_rate_limited
 def test_huggingface_source_caching(artifacts_dir: Path) -> None:
     """Test that models are cached after first download."""
     source = HuggingfaceSource(num_models=1, output_dir=str(artifacts_dir))
@@ -85,6 +107,7 @@ def test_huggingface_source_caching(artifacts_dir: Path) -> None:
     assert allocations1 == allocations2
 
 
+@skip_when_rate_limited
 def test_huggingface_source_allocation_kinds(artifacts_dir: Path) -> None:
     """Test that allocations have appropriate allocation kinds."""
     source = HuggingfaceSource(num_models=1, output_dir=str(artifacts_dir))


### PR DESCRIPTION
The Checks badge on main went red because one matrix job of the run for
8fc9b85 was throttled by the Hugging Face Hub, which answered 429 to
every API call for several minutes. Parallel CI jobs share GitHub
Actions IP ranges, so a single job losing the rate limit lottery is
expected and says nothing about the code.

The five tests that reach the Hub now skip when a request ultimately
fails with HTTP 429 instead of failing the run. Every other HTTP error
still fails loudly, and transient throttling on the download path keeps
being retried with backoff inside huggingface_hub before the error
surfaces.
