### PR TITLE
Add a stress and profiling harness, and fix the two defects it found

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ dev = [
 
 [tool.scikit-build]
 wheel.packages = ["src/python/omnimalloc"]
-cmake.build-type = "Release"                                            # TODO(fpedd): Cross-check with CMakeLists.txt
+cmake.build-type = "Release"
 build-dir = "build/{wheel_tag}"
 sdist.include = ["src/cpp/**"]
 sdist.exclude = [".github", "notebooks", "external"]
@@ -143,7 +143,7 @@ ignore = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = ["--import-mode=importlib", "-m", "not slow"]
-pythonpath = ["."] # importlib mode drops it; spawned workers import tests from it
+pythonpath = ["."]
 markers = ["slow: exhaustive stress grids (deselected by default)"]
 log_cli = true
 log_cli_level = "INFO"
@@ -160,4 +160,4 @@ unused-type-ignore-comment = "ignore"
 python-version = "3.10"
 
 [tool.ty.src]
-exclude = ["tests/", "**/*.pyi"]
+exclude = ["tests/", "**/*.pyi", "scripts/stress/contracts.py"]

--- a/scripts/stress/contracts.py
+++ b/scripts/stress/contracts.py
@@ -1,0 +1,381 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Record what every public entry point does on hostile input.
+
+Prints one row per probe rather than asserting, so the whole contract surface
+reads at once and an inconsistency shows up as the odd row out.
+"""
+
+from collections.abc import Callable
+
+from omnimalloc import Allocation, Memory, Pool, System, allocate, validate_allocation
+from omnimalloc.allocators import BaseAllocator
+from omnimalloc.analysis import (
+    antichain_pressure,
+    antichain_pressure_per_allocation,
+    closure_pressure,
+    conflict_degrees,
+    conflict_graph,
+    conflicts,
+    placement_pressure,
+    placement_pressure_per_allocation,
+    try_linearize,
+)
+from omnimalloc.common.constants import KB
+
+Probe = tuple[str, Callable[[], object]]
+
+SCALAR = tuple(Allocation(id=i, size=KB, start=i, end=i + 3) for i in range(4))
+VECTOR = tuple(
+    Allocation(id=i, size=KB, start=(i, 0), end=(i + 3, 1)) for i in range(4)
+)
+PLACED = tuple(a.with_offset(0 if i % 2 else KB) for i, a in enumerate(SCALAR))
+MIXED = (SCALAR[0], VECTOR[1])
+DUPLICATE = (SCALAR[0], SCALAR[0])
+
+# Dense enough that the budgeted entry points have something to refuse
+BIG_SCALAR = tuple(Allocation(id=i, size=KB, start=0, end=2) for i in range(2000))
+BIG_VECTOR = tuple(
+    Allocation(id=i, size=KB, start=(i % 7, i % 5, 0), end=(i % 7 + 2, i % 5 + 2, 2))
+    for i in range(2000)
+)
+
+MAX_OUTCOME = 90
+
+
+def probe(call: Callable[[], object]) -> str:
+    try:
+        value = call()
+    except Exception as e:  # noqa: BLE001
+        return f"{type(e).__name__}: {str(e).splitlines()[0]}"[:160]
+    text = repr(value)
+    return f"ok: {text if len(text) <= MAX_OUTCOME else text[:MAX_OUTCOME] + '...'}"
+
+
+def section(title: str, probes: list[Probe]) -> None:
+    print(f"\n===== {title}")
+    for label, call in probes:
+        print(f"  {label:<50} {probe(call)}")
+
+
+def allocation_probes() -> list[Probe]:
+    return [
+        ("size=0", lambda: Allocation(id=0, size=0, start=0, end=1)),
+        ("size=-1", lambda: Allocation(id=0, size=-1, start=0, end=1)),
+        ("end == start", lambda: Allocation(id=0, size=1, start=5, end=5)),
+        ("end < start", lambda: Allocation(id=0, size=1, start=5, end=4)),
+        ("start=-1", lambda: Allocation(id=0, size=1, start=-1, end=1)),
+        ("offset=-1", lambda: Allocation(id=0, size=1, start=0, end=1, offset=-1)),
+        ("size=2**63", lambda: Allocation(id=0, size=2**63, start=0, end=1)),
+        (
+            "offset + size overflows int64",
+            lambda: Allocation(id=0, size=2**62, start=0, end=1, offset=2**62),
+        ),
+        ("id=None", lambda: Allocation(id=None, size=1, start=0, end=1)),
+        ("id=1.5", lambda: Allocation(id=1.5, size=1, start=0, end=1)),
+        ("id=''", lambda: Allocation(id="", size=1, start=0, end=1)),
+        (
+            "mismatched clock dims",
+            lambda: Allocation(id=0, size=1, start=(0, 0), end=(1, 1, 1)),
+        ),
+        ("empty clock", lambda: Allocation(id=0, size=1, start=(), end=())),
+        (
+            "1-tuple normalizes",
+            lambda: Allocation(id=0, size=1, start=(0,), end=(1,)).dim,
+        ),
+        (
+            "scalar start, vector end",
+            lambda: Allocation(id=0, size=1, start=0, end=(1, 1)),
+        ),
+        (
+            "vector end not >= start",
+            lambda: Allocation(id=0, size=1, start=(1, 1), end=(0, 2)),
+        ),
+        (
+            "vector end == start",
+            lambda: Allocation(id=0, size=1, start=(1, 1), end=(1, 1)),
+        ),
+        ("with_offset(-1)", lambda: SCALAR[0].with_offset(-1)),
+        ("with_offset(None)", lambda: PLACED[0].with_offset(None).offset),
+        ("height while unplaced", lambda: SCALAR[0].height),
+        ("conflicts_with across dims", lambda: SCALAR[0].conflicts_with(VECTOR[0])),
+        ("__eq__ against a non-Allocation", lambda: SCALAR[0] == 5),
+        (
+            "repr distinguishes 1 from '1'",
+            lambda: (
+                repr(Allocation(id=1, size=1, start=0, end=1))
+                != repr(Allocation(id="1", size=1, start=0, end=1))
+            ),
+        ),
+    ]
+
+
+def analysis_probes() -> list[Probe]:
+    return [
+        ("antichain_pressure([])", lambda: antichain_pressure([])),
+        ("closure_pressure([])", lambda: closure_pressure([])),
+        ("conflict_degrees([])", lambda: conflict_degrees([])),
+        ("conflicts([])", lambda: conflicts([])),
+        ("placement_pressure([])", lambda: placement_pressure([])),
+        ("try_linearize([])", lambda: try_linearize([])),
+        ("antichain_pressure(mixed dims)", lambda: antichain_pressure(MIXED)),
+        ("conflict_degrees(mixed dims)", lambda: conflict_degrees(MIXED)),
+        ("try_linearize(mixed dims)", lambda: try_linearize(MIXED)),
+        ("conflicts(duplicate ids)", lambda: conflicts(DUPLICATE)),
+        ("conflict_degrees(duplicate ids)", lambda: conflict_degrees(DUPLICATE)),
+        (
+            "pressure_per_allocation(duplicate ids)",
+            lambda: antichain_pressure_per_allocation(DUPLICATE),
+        ),
+        ("placement_pressure(unplaced)", lambda: placement_pressure(SCALAR)),
+        (
+            "placement_pressure(partly placed)",
+            lambda: placement_pressure(PLACED[:2] + SCALAR[2:]),
+        ),
+        (
+            "placement_pressure_per_allocation(unplaced)",
+            lambda: placement_pressure_per_allocation(SCALAR),
+        ),
+        (
+            "scalar antichain, work_budget=0",
+            lambda: antichain_pressure(BIG_SCALAR, work_budget=0),
+        ),
+        (
+            "scalar degrees, work_budget=0",
+            lambda: max(conflict_degrees(BIG_SCALAR, work_budget=0)),
+        ),
+        (
+            "scalar closure, closure_cap=0",
+            lambda: closure_pressure(BIG_SCALAR, closure_cap=0),
+        ),
+        (
+            "vector antichain, work_budget=0",
+            lambda: antichain_pressure(BIG_VECTOR, work_budget=0),
+        ),
+        (
+            "vector degrees, work_budget=0",
+            lambda: conflict_degrees(BIG_VECTOR, work_budget=0),
+        ),
+        (
+            "vector closure, closure_cap=0",
+            lambda: closure_pressure(BIG_VECTOR, closure_cap=0),
+        ),
+        ("work_budget=-1", lambda: antichain_pressure(BIG_VECTOR, work_budget=-1)),
+        ("closure_cap=-1", lambda: closure_pressure(BIG_VECTOR, closure_cap=-1)),
+        ("conflicts at its default budget", lambda: len(conflicts(BIG_SCALAR))),
+        (
+            "conflict_graph(max_entries=0)",
+            lambda: conflict_graph(BIG_SCALAR, max_entries=0),
+        ),
+        (
+            "conflict_graph(max_entries=-1)",
+            lambda: conflict_graph(BIG_SCALAR, max_entries=-1),
+        ),
+        ("neighbors(-1)", lambda: conflict_graph(SCALAR).neighbors(-1)),
+        ("neighbors(past the end)", lambda: conflict_graph(SCALAR).neighbors(99)),
+        ("antichain_pressure(42)", lambda: antichain_pressure(42)),
+        ("antichain_pressure([1, 2, 3])", lambda: antichain_pressure([1, 2, 3])),
+        (
+            "antichain_pressure(generator)",
+            lambda: antichain_pressure(a for a in SCALAR),
+        ),
+        ("conflict_degrees('abc')", lambda: conflict_degrees("abc")),
+    ]
+
+
+def allocate_probes() -> list[Probe]:
+    colliding = tuple(a.with_offset(0) for a in SCALAR)
+    return [
+        ("allocate([])", lambda: allocate([])),
+        ("allocate(empty Pool)", lambda: allocate(Pool(id="p", allocations=()))),
+        ("allocate(empty Memory)", lambda: allocate(Memory(id="m", pools=()))),
+        ("allocate(empty System)", lambda: allocate(System(id="s", memories=()))),
+        ("unknown allocator name", lambda: allocate(SCALAR, "nope")),
+        ("allocator that is not one", lambda: allocate(SCALAR, dict)),
+        (
+            "allocator as a class",
+            lambda: len(allocate(SCALAR, BaseAllocator.get("omni"))),
+        ),
+        ("allocate(42)", lambda: allocate(42)),
+        ("allocate('abc')", lambda: allocate("abc")),
+        ("allocate([1, 2, 3])", lambda: allocate([1, 2, 3])),
+        ("allocate(duplicate ids)", lambda: allocate(DUPLICATE)),
+        ("allocate(mixed dims)", lambda: allocate(MIXED)),
+        ("vector through omni", lambda: len(allocate(VECTOR, "omni"))),
+        ("pins through omni", lambda: [a.offset for a in allocate(PLACED, "omni")]),
+        ("pins through naive", lambda: allocate(PLACED, "naive")),
+        ("pins that already collide", lambda: allocate(colliding, "omni")),
+        ("validate=True", lambda: len(allocate(SCALAR, "omni", validate=True))),
+        (
+            "Pool in, Pool out",
+            lambda: type(allocate(Pool(id="p", allocations=SCALAR))).__name__,
+        ),
+        ("list in, tuple out", lambda: type(allocate(list(SCALAR))).__name__),
+    ]
+
+
+def validate_probes() -> list[Probe]:
+    overlapping = (
+        Allocation(id=0, size=KB, start=0, end=2, offset=0),
+        Allocation(id=1, size=KB, start=1, end=3, offset=0),
+    )
+    stacked = (
+        Allocation(id=0, size=KB, start=0, end=2, offset=0),
+        Allocation(id=1, size=KB, start=1, end=3, offset=KB),
+    )
+    duplicate = (
+        Allocation(id="x", size=KB, start=0, end=2, offset=0),
+        Allocation(id="x", size=KB, start=5, end=7, offset=0),
+    )
+    other_pool = (Allocation(id="z", size=KB, start=0, end=2, offset=0),)
+    return [
+        ("validate([])", lambda: validate_allocation([])),
+        ("a clean placement", lambda: validate_allocation(stacked)),
+        ("overlapping allocations", lambda: validate_allocation(overlapping)),
+        ("duplicate ids", lambda: validate_allocation(duplicate)),
+        ("unplaced", lambda: validate_allocation(SCALAR)),
+        (
+            "unplaced, require_allocated=False",
+            lambda: validate_allocation(SCALAR, require_allocated=False),
+        ),
+        ("alignment=0", lambda: validate_allocation(stacked, alignment=0)),
+        ("alignment=-8", lambda: validate_allocation(stacked, alignment=-8)),
+        ("alignment honored", lambda: validate_allocation(stacked, alignment=KB)),
+        ("alignment violated", lambda: validate_allocation(stacked, alignment=2 * KB)),
+        ("validate(42)", lambda: validate_allocation(42)),
+        ("validate([1, 2, 3])", lambda: validate_allocation([1, 2, 3])),
+        (
+            "no size, require_capacity=True",
+            lambda: validate_allocation(
+                Memory(id="m", pools=(Pool(id="p", allocations=stacked, offset=0),)),
+                require_capacity=True,
+            ),
+        ),
+        (
+            "memory too small",
+            lambda: validate_allocation(
+                Memory(
+                    id="m", size=1, pools=(Pool(id="p", allocations=stacked, offset=0),)
+                )
+            ),
+        ),
+        (
+            "memory large enough",
+            lambda: validate_allocation(
+                Memory(
+                    id="m",
+                    size=1 << 30,
+                    pools=(Pool(id="p", allocations=stacked, offset=0),),
+                )
+            ),
+        ),
+        (
+            "unplaced pool",
+            lambda: validate_allocation(
+                Memory(id="m", pools=(Pool(id="p", allocations=stacked),))
+            ),
+        ),
+        (
+            "overlapping pools",
+            lambda: validate_allocation(
+                Memory(
+                    id="m",
+                    pools=(
+                        Pool(id="a", allocations=stacked, offset=0),
+                        Pool(id="b", allocations=other_pool, offset=1),
+                    ),
+                )
+            ),
+        ),
+        (
+            "ids repeated across pools",
+            lambda: validate_allocation(
+                Memory(
+                    id="m",
+                    pools=(
+                        Pool(id="a", allocations=stacked, offset=0),
+                        Pool(id="b", allocations=stacked, offset=1 << 20),
+                    ),
+                )
+            ),
+        ),
+    ]
+
+
+def hierarchy_probes() -> list[Probe]:
+    return [
+        ("Pool(offset=-1)", lambda: Pool(id="p", allocations=(), offset=-1)),
+        ("Pool(duplicate ids)", lambda: Pool(id="p", allocations=DUPLICATE)),
+        ("Pool(non-Allocation)", lambda: Pool(id="p", allocations=(1, 2))),
+        ("Pool(str)", lambda: Pool(id="p", allocations="ab")),
+        ("Pool.size while unallocated", lambda: Pool(id="p", allocations=SCALAR).size),
+        ("Pool.size when empty", lambda: Pool(id="p", allocations=()).size),
+        ("Pool.efficiency when empty", lambda: Pool(id="p", allocations=()).efficiency),
+        ("Pool.pressure", lambda: Pool(id="p", allocations=SCALAR).pressure),
+        ("Pool.pressure(mixed dims)", lambda: Pool(id="p", allocations=MIXED).pressure),
+        ("Memory(size=-1)", lambda: Memory(id="m", size=-1, pools=())),
+        (
+            "Memory(duplicate pool ids)",
+            lambda: Memory(
+                id="m",
+                pools=(Pool(id="p", allocations=()), Pool(id="p", allocations=())),
+            ),
+        ),
+        (
+            "Memory.extent while unplaced",
+            lambda: Memory(id="m", pools=(Pool(id="p", allocations=PLACED),)).extent,
+        ),
+        (
+            "System(duplicate memory ids)",
+            lambda: System(
+                id="s", memories=(Memory(id="m", pools=()), Memory(id="m", pools=()))
+            ),
+        ),
+        ("System(non-Memory)", lambda: System(id="s", memories=(1,))),
+        (
+            "frozen dataclass assignment",
+            lambda: setattr(Pool(id="p", allocations=()), "id", "q"),
+        ),
+    ]
+
+
+def registry_probes() -> list[Probe]:
+    return [
+        ("get('omni')", lambda: BaseAllocator.get("omni").__name__),
+        ("get('OMNI')", lambda: BaseAllocator.get("OMNI")),
+        ("get('')", lambda: BaseAllocator.get("")),
+        ("resolve(None)", lambda: BaseAllocator.resolve(None)),
+        (
+            "registry() hands out a copy",
+            lambda: (
+                BaseAllocator.registry().pop("omni"),
+                "omni" in BaseAllocator.registry(),
+            )[1],
+        ),
+        (
+            "allocators taking vector clocks",
+            lambda: sorted(
+                n for n, c in BaseAllocator.registry().items() if c.supports_vector_time
+            ),
+        ),
+        (
+            "allocators honoring pins",
+            lambda: sorted(
+                n for n, c in BaseAllocator.registry().items() if c.supports_pinned
+            ),
+        ),
+    ]
+
+
+def main() -> None:
+    section("Allocation constructor and accessors", allocation_probes())
+    section("Analysis entry points", analysis_probes())
+    section("allocate()", allocate_probes())
+    section("validate_allocation()", validate_probes())
+    section("Hierarchy primitives", hierarchy_probes())
+    section("Registry", registry_probes())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/fuzz.py
+++ b/scripts/stress/fuzz.py
@@ -1,0 +1,289 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Sweep every workload through the analysis API and every applicable allocator.
+
+Cells run on a thread pool, so the kernels are exercised concurrently and a
+race in a GIL-releasing kernel surfaces as a mismatch rather than staying quiet.
+"""
+
+import argparse
+import json
+import random
+import sys
+import time
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from invariants import (
+    check_conflicts,
+    check_lane_invariance,
+    check_linearize,
+    check_order_invariance,
+    check_pickle,
+    check_placement,
+    check_pressure,
+    peak_of,
+)
+from omnimalloc import allocate, validate_allocation
+from omnimalloc.allocators import BaseAllocator
+from omnimalloc.analysis import antichain_pressure
+from omnimalloc.primitives import Allocation, IdType, Memory, Pool, System
+from workloads import Workload, catalog
+
+# The search allocators get a short budget: this sweep checks contracts, and
+# their default seconds-scale budgets would dominate its runtime.
+FAST_KWARGS: dict[str, dict[str, float | int]] = {
+    "genetic": {"population_size": 12, "generations": 4, "timeout": 1.0},
+    "simulated_annealing": {"max_iterations": 500, "timeout": 1.0},
+    "tabu_search": {"max_iterations": 200, "timeout": 1.0},
+    "hill_climb": {"iterations": 200, "timeout": 1.0},
+    "supermalloc": {"timeout": 1.0},
+    "telamalloc": {"timeout": 1.0},
+}
+
+# Brute-force references are quadratic, so they run only on small instances
+BRUTE_LIMIT = 200
+CLIQUE_LIMIT = 26
+
+# Wrapper around a separately installed package, absent by default
+OPTIONAL = frozenset({"minimalloc"})
+
+
+def build_allocator(name: str) -> BaseAllocator | None:
+    """Instantiate with the sweep's short budget, or plainly, or not at all."""
+    allocator_type = BaseAllocator.get(name)
+    try:
+        return allocator_type(**FAST_KWARGS.get(name, {}))
+    except (TypeError, ImportError, RuntimeError):
+        try:
+            return allocator_type()
+        except Exception:  # noqa: BLE001
+            return None
+
+
+def fresh(name: str) -> BaseAllocator:
+    """A new instance of an allocator already known to construct.
+
+    Search allocators carry per-run state, so every call gets its own.
+    """
+    allocator = build_allocator(name)
+    assert allocator is not None
+    return allocator
+
+
+def pin_subset(
+    placed: tuple[Allocation, ...], fraction: float, rng: random.Random
+) -> tuple[tuple[Allocation, ...], dict[IdType, int]]:
+    """Re-pose a known-good placement with a random subset pinned."""
+    pinned = tuple(
+        alloc if rng.random() < fraction else alloc.with_offset(None)
+        for alloc in placed
+    )
+    return pinned, {a.id: a.offset for a in pinned if a.offset is not None}
+
+
+def check_hierarchy(
+    allocations: tuple[Allocation, ...], allocator: BaseAllocator
+) -> list[str]:
+    """The System, Memory and Pool paths must agree with the flat one."""
+    fails = []
+    flat = allocate(allocations, allocator)
+    from_pool = allocate(Pool(id="p0", allocations=allocations), allocator)
+    if [a.offset for a in from_pool.allocations] != [a.offset for a in flat]:
+        fails.append("the Pool path disagrees with the flat path")
+    if [a.id for a in from_pool.allocations] != [a.id for a in allocations]:
+        fails.append("Pool.allocate did not preserve the input order")
+
+    half = len(allocations) // 2 or len(allocations)
+    renamed = tuple(
+        Allocation(id=f"b_{a.id}", size=a.size, start=a.start, end=a.end, kind=a.kind)
+        for a in allocations[half:]
+    )
+    memory = Memory(
+        id="m0",
+        pools=(
+            Pool(id="a", allocations=allocations[:half]),
+            Pool(id="b", allocations=renamed),
+        ),
+    )
+    placed = allocate(System(id="s0", memories=(memory,)), allocator)
+    if not placed.is_allocated:
+        fails.append("System.allocate left something unplaced")
+    try:
+        validate_allocation(placed)
+    except ValueError as e:
+        fails.append(f"the System placement failed validation, {e}")
+
+    pools = placed.memories[0].pools
+    based = [(pool.offset, pool) for pool in pools if pool.offset is not None]
+    if len(based) != len(pools):
+        fails.append("Memory.allocate left a pool without a base")
+    elif placed.memories[0].extent < max(base + pool.size for base, pool in based):
+        fails.append("Memory.extent sits below the top of its pools")
+    return fails
+
+
+def check_allocator(
+    allocations: tuple[Allocation, ...],
+    name: str,
+    rng: random.Random,
+    deep: bool,
+) -> tuple[list[str], int | None, float | None]:
+    """Run one allocator and check its result, its determinism, and its pins."""
+    allocator = build_allocator(name)
+    if allocator is None or not allocator.supports(allocations):
+        return [], None, None
+    try:
+        started = time.perf_counter()
+        placed = tuple(allocator.allocate(allocations))
+        seconds = time.perf_counter() - started
+    except Exception as e:  # noqa: BLE001
+        if name in OPTIONAL and isinstance(e, ImportError | RuntimeError):
+            return [], None, None
+        return [f"{name}: raised {type(e).__name__}, {e}"], None, None
+
+    fails = check_placement(allocations, placed, name, {})
+    repeat = tuple(fresh(name).allocate(allocations))
+    if [a.offset for a in repeat] != [a.offset for a in placed]:
+        fails.append(f"{name}: not deterministic across two identical calls")
+    if deep:
+        fails += _check_pins(allocations, placed, name, rng, allocator)
+    return fails, peak_of(placed), seconds
+
+
+def _check_pins(
+    allocations: tuple[Allocation, ...],
+    placed: tuple[Allocation, ...],
+    name: str,
+    rng: random.Random,
+    allocator: BaseAllocator,
+) -> list[str]:
+    """Honor pins, or refuse them; silently re-placing them is the failure."""
+    pinned, pins = pin_subset(placed, 0.3, rng)
+    if allocator.supports_pinned:
+        try:
+            repinned = tuple(fresh(name).allocate(pinned))
+        except Exception as e:  # noqa: BLE001
+            return [f"{name}[pinned]: raised {type(e).__name__}, {e}"]
+        return check_placement(allocations, repinned, f"{name}[pinned]", pins)
+    if not pins:
+        return []
+    try:
+        fresh(name).allocate(pinned)
+    except ValueError:
+        return []
+    return [f"{name}: accepted pins although supports_pinned is False"]
+
+
+def run_cell(
+    workload: Workload, size: int, seed: int, allocators: list[str], deep: bool
+) -> dict:
+    """One (workload, size, seed) cell: analysis first, then every allocator."""
+    rng = random.Random(seed * 7919 + size)
+    allocations = workload.allocations(size, seed)
+    if not allocations:
+        return {"workload": workload.name, "size": size, "seed": seed, "failures": []}
+
+    count = len(allocations)
+    fails = check_conflicts(allocations, brute=count <= BRUTE_LIMIT)
+    fails += check_pressure(allocations, brute=count <= CLIQUE_LIMIT)
+    fails += check_order_invariance(allocations, rng)
+    fails += check_lane_invariance(allocations, rng)
+    fails += check_linearize(allocations)
+    fails += check_pickle(allocations)
+
+    peaks: dict[str, int] = {}
+    timings: dict[str, float] = {}
+    for name in allocators:
+        allocator_fails, peak, seconds = check_allocator(allocations, name, rng, deep)
+        fails += allocator_fails
+        if peak is not None:
+            peaks[name] = peak
+        if seconds is not None:
+            timings[name] = seconds
+
+    if deep and "omni" in peaks:
+        fails += check_hierarchy(allocations, fresh("omni"))
+
+    return {
+        "workload": workload.name,
+        "family": workload.family,
+        "dim": allocations[0].dim,
+        "size": count,
+        "seed": seed,
+        "bound": antichain_pressure(allocations),
+        "known_optimum": workload.known_optimum,
+        "peaks": peaks,
+        "timings": timings,
+        "failures": fails,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sizes", type=int, nargs="+", default=[1, 2, 3, 7, 33, 64, 257]
+    )
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 1, 2])
+    parser.add_argument("--allocators", nargs="+", default=None)
+    parser.add_argument("--workers", type=int, default=12)
+    parser.add_argument(
+        "--deep", action="store_true", help="also check pins and the hierarchy paths"
+    )
+    parser.add_argument("--out", type=Path, default=Path("fuzz_results.json"))
+    args = parser.parse_args()
+
+    allocators = args.allocators or sorted(BaseAllocator.registry())
+    cells = [
+        (workload, size, seed)
+        for workload in catalog()
+        for size in args.sizes
+        for seed in args.seeds
+    ]
+    print(f"{len(cells)} cells over {len(allocators)} allocators", flush=True)
+
+    def work(cell: tuple[Workload, int, int]) -> dict:
+        workload, size, seed = cell
+        try:
+            return run_cell(workload, size, seed, allocators, args.deep)
+        except Exception:  # noqa: BLE001
+            return {
+                "workload": workload.name,
+                "size": size,
+                "seed": seed,
+                "failures": [f"HARNESS: {traceback.format_exc(limit=6)}"],
+            }
+
+    results = []
+    failures = 0
+    started = time.perf_counter()
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        for index, result in enumerate(pool.map(work, cells)):
+            results.append(result)
+            for failure in result["failures"]:
+                failures += 1
+                print(
+                    f"FAIL [{result['workload']} n={result.get('size')} "
+                    f"seed={result.get('seed')}] {failure}",
+                    flush=True,
+                )
+            if (index + 1) % 100 == 0:
+                print(
+                    f"  {index + 1}/{len(cells)} cells, {failures} failures, "
+                    f"{time.perf_counter() - started:.0f}s",
+                    flush=True,
+                )
+
+    args.out.write_text(json.dumps(results, indent=1, default=str))
+    placements = sum(len(cell.get("peaks", {})) for cell in results)
+    print(
+        f"\n{len(cells)} cells, {placements} placements, {failures} failures, "
+        f"{time.perf_counter() - started:.0f}s, wrote {args.out}"
+    )
+    sys.exit(1 if failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/invariants.py
+++ b/scripts/stress/invariants.py
@@ -1,0 +1,438 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Invariant checks for the public API, returning failure strings.
+
+The reference implementations here are deliberately naive Python, never the
+C++ kernels, so a kernel bug cannot hide behind itself.
+"""
+
+import pickle
+import random
+from collections.abc import Sequence
+
+from omnimalloc import validate_allocation
+from omnimalloc._cpp import ConflictGraph
+from omnimalloc.analysis import (
+    antichain_pressure,
+    antichain_pressure_per_allocation,
+    closure_pressure,
+    closure_pressure_per_allocation,
+    conflict_degrees,
+    conflict_graph,
+    conflicts,
+    placement_pressure,
+    placement_pressure_per_allocation,
+    try_linearize,
+)
+from omnimalloc.analysis.clock import time_components
+from omnimalloc.primitives import Allocation, IdType
+
+Allocs = Sequence[Allocation]
+
+# Above this the exact clique search stops being worth its runtime
+CLIQUE_LIMIT = 26
+
+
+def brute_conflict_pairs(allocations: Allocs) -> set[tuple[int, int]]:
+    """Every conflicting index pair, straight off ``Allocation.conflicts_with``."""
+    return {
+        (i, j)
+        for i in range(len(allocations))
+        for j in range(i + 1, len(allocations))
+        if allocations[i].conflicts_with(allocations[j])
+    }
+
+
+def brute_scalar_pressure(allocations: Allocs) -> int:
+    """Max total size live at one instant; scalar lifetimes only.
+
+    Every cut that can be maximal starts at some allocation, so the starts are
+    the only instants worth probing.
+    """
+    spans = [
+        (time_components(a.start)[0], time_components(a.end)[0], a.size)
+        for a in allocations
+    ]
+    peak = 0
+    for cut in {start for start, _, _ in spans}:
+        live = sum(size for start, end, size in spans if start <= cut < end)
+        peak = max(peak, live)
+    return peak
+
+
+def brute_collisions(allocations: Allocs) -> list[tuple[int, int]]:
+    """Index pairs overlapping in both time and address space."""
+    bad = []
+    for i, first in enumerate(allocations):
+        if first.offset is None:
+            continue
+        low, high = first.offset, first.offset + first.size
+        for j in range(i + 1, len(allocations)):
+            second = allocations[j]
+            if second.offset is None:
+                continue
+            other_low, other_high = second.offset, second.offset + second.size
+            if low < other_high and other_low < high:
+                if first.conflicts_with(second):
+                    bad.append((i, j))
+    return bad
+
+
+def brute_max_clique_weight(allocations: Allocs) -> int | None:
+    """Exact max-weight clique of the conflict graph, or None when too large.
+
+    A clique must occupy disjoint addresses, so its weight lower-bounds any
+    placement's peak, and the maximum is exactly ``antichain_pressure``.
+    """
+    n = len(allocations)
+    if n > CLIQUE_LIMIT:
+        return None
+    adjacency = [0] * n
+    for i, j in brute_conflict_pairs(allocations):
+        adjacency[i] |= 1 << j
+        adjacency[j] |= 1 << i
+    sizes = [a.size for a in allocations]
+    best = 0
+
+    def expand(candidates: int, weight: int) -> None:
+        nonlocal best
+        best = max(best, weight)
+        reachable = weight + sum(sizes[k] for k in range(n) if candidates >> k & 1)
+        if reachable <= best:
+            return
+        remaining = candidates
+        while remaining:
+            pivot = (remaining & -remaining).bit_length() - 1
+            remaining &= ~(1 << pivot)
+            above_pivot = ~((1 << (pivot + 1)) - 1)
+            expand(candidates & adjacency[pivot] & above_pivot, weight + sizes[pivot])
+
+    expand((1 << n) - 1, 0)
+    return best
+
+
+def peak_of(placed: Allocs) -> int:
+    """Highest occupied address, ignoring anything still unplaced."""
+    heights = [a.height for a in placed if a.height is not None]
+    return max(heights, default=0)
+
+
+def closure_or_none(allocations: Allocs) -> int | None:
+    """The default cap refuses wide vector clocks, and that is an answer."""
+    try:
+        return closure_pressure(allocations)
+    except RuntimeError:
+        return None
+
+
+def check_conflicts(allocations: Allocs, brute: bool) -> list[str]:
+    """The three conflict entry points must describe one identical relation."""
+    fails = []
+    n = len(allocations)
+    degrees = conflict_degrees(allocations)
+    graph = conflict_graph(allocations)
+
+    if len(degrees) != n:
+        fails.append(f"conflict_degrees length {len(degrees)} != {n}")
+    if len(graph) != n:
+        fails.append(f"len(conflict_graph) {len(graph)} != {n}")
+    if [graph.degree(i) for i in range(len(graph))] != degrees:
+        fails.append("conflict_graph.degree disagrees with conflict_degrees")
+
+    neighbor_sets = [set(graph.neighbors(i)) for i in range(len(graph))]
+    fails += _check_rows(graph, neighbor_sets, degrees)
+
+    total = sum(degrees)
+    if total % 2:
+        fails.append(f"degree sum {total} is odd")
+    if graph.pair_count != total // 2:
+        fails.append(f"pair_count {graph.pair_count} != half the degree sum")
+
+    fails += _check_conflict_map(allocations, neighbor_sets)
+    if brute:
+        graph_pairs = {
+            (min(i, j), max(i, j))
+            for i, neighbors in enumerate(neighbor_sets)
+            for j in neighbors
+        }
+        expected = brute_conflict_pairs(allocations)
+        if graph_pairs != expected:
+            fails.append(
+                f"conflict_graph vs conflicts_with: {len(expected - graph_pairs)} "
+                f"missing, {len(graph_pairs - expected)} extra"
+            )
+    return fails
+
+
+def _check_rows(
+    graph: ConflictGraph, neighbor_sets: list[set[int]], degrees: list[int]
+) -> list[str]:
+    """Each row is duplicate-free, irreflexive, symmetric, and the right length."""
+    for i, neighbors in enumerate(neighbor_sets):
+        if len(neighbors) != len(graph.neighbors(i)):
+            return [f"conflict_graph.neighbors({i}) repeats a neighbor"]
+        if i in neighbors:
+            return [f"conflict_graph is reflexive at {i}"]
+        if len(neighbors) != degrees[i]:
+            return [f"degree {degrees[i]} disagrees with |neighbors| at {i}"]
+        if any(i not in neighbor_sets[j] for j in neighbors):
+            return [f"conflict_graph is asymmetric at {i}"]
+    return []
+
+
+def _check_conflict_map(
+    allocations: Allocs, neighbor_sets: list[set[int]]
+) -> list[str]:
+    ids = [a.id for a in allocations]
+    if len(set(ids)) != len(ids):
+        return []
+    mapping = conflicts(allocations)
+    if set(mapping) != set(ids):
+        return ["conflicts() keys differ from the allocation ids"]
+    for i, alloc in enumerate(allocations):
+        if mapping[alloc.id] != {ids[j] for j in neighbor_sets[i]}:
+            return [f"conflicts()[{alloc.id!r}] differs from the graph"]
+    return []
+
+
+def check_pressure(allocations: Allocs, brute: bool) -> list[str]:
+    """The bound order, the per-allocation split, and the exact references."""
+    antichain = antichain_pressure(allocations)
+    closure = closure_or_none(allocations)
+    fails = _check_bound_range(allocations, antichain, closure)
+    fails += _check_per_allocation(allocations, antichain, closure)
+
+    if allocations and allocations[0].dim == 1:
+        reference = brute_scalar_pressure(allocations)
+        if antichain != reference:
+            fails.append(f"scalar antichain {antichain} != sweep {reference}")
+        if closure != reference:
+            fails.append(f"scalar closure {closure} != sweep {reference}")
+    if brute:
+        clique = brute_max_clique_weight(allocations)
+        if clique is not None and clique != antichain:
+            fails.append(f"antichain {antichain} != exact max clique {clique}")
+    return fails
+
+
+def _check_bound_range(
+    allocations: Allocs, antichain: int, closure: int | None
+) -> list[str]:
+    """Both bounds sit between the largest single size and the total."""
+    largest = max((a.size for a in allocations), default=0)
+    fails = []
+    if antichain < 0:
+        fails.append(f"negative antichain_pressure {antichain}")
+    if allocations and antichain < largest:
+        fails.append(f"antichain_pressure {antichain} below largest size {largest}")
+    if antichain > sum(a.size for a in allocations):
+        fails.append(f"antichain_pressure {antichain} above the total size")
+    if closure is None:
+        return fails
+    if closure > antichain:
+        fails.append(f"closure_pressure {closure} above antichain {antichain}")
+    if allocations and closure < largest:
+        fails.append(f"closure_pressure {closure} below largest size {largest}")
+    return fails
+
+
+def _check_per_allocation(
+    allocations: Allocs, antichain: int, closure: int | None
+) -> list[str]:
+    """Each per-allocation map peaks at its aggregate and covers its own size."""
+    ids = [a.id for a in allocations]
+    if len(set(ids)) != len(ids):
+        return []
+    fails = []
+    per_antichain = antichain_pressure_per_allocation(allocations)
+    if max(per_antichain.values(), default=0) != antichain:
+        fails.append("max antichain_pressure_per_allocation != antichain_pressure")
+    for alloc in allocations:
+        if per_antichain[alloc.id] < alloc.size:
+            fails.append(f"antichain per-allocation below own size at {alloc.id!r}")
+            break
+    if closure is None:
+        return fails
+
+    per_closure = closure_pressure_per_allocation(allocations)
+    if max(per_closure.values(), default=0) != closure:
+        fails.append("max closure_pressure_per_allocation != closure_pressure")
+    for alloc in allocations:
+        if per_closure[alloc.id] < alloc.size:
+            fails.append(f"closure per-allocation below own size at {alloc.id!r}")
+            break
+        if per_closure[alloc.id] > per_antichain[alloc.id]:
+            fails.append(f"per-allocation closure above antichain at {alloc.id!r}")
+            break
+    return fails
+
+
+def check_order_invariance(allocations: Allocs, rng: random.Random) -> list[str]:
+    """Analysis reads a set, so a shuffled input must answer identically."""
+    order = list(range(len(allocations)))
+    rng.shuffle(order)
+    shuffled = tuple(allocations[i] for i in order)
+    fails = []
+
+    if antichain_pressure(shuffled) != antichain_pressure(allocations):
+        fails.append("antichain_pressure depends on input order")
+    if closure_or_none(shuffled) != closure_or_none(allocations):
+        fails.append("closure_pressure depends on input order")
+
+    shuffled_degrees = conflict_degrees(shuffled)
+    restored = [shuffled_degrees[order.index(i)] for i in range(len(order))]
+    if restored != conflict_degrees(allocations):
+        fails.append("conflict_degrees is not permutation-equivariant")
+
+    ids = [a.id for a in allocations]
+    if len(set(ids)) == len(ids):
+        if antichain_pressure_per_allocation(
+            shuffled
+        ) != antichain_pressure_per_allocation(allocations):
+            fails.append("antichain_pressure_per_allocation depends on input order")
+    return fails
+
+
+def check_lane_invariance(allocations: Allocs, rng: random.Random) -> list[str]:
+    """Clock lanes are unordered, so permuting them must change nothing."""
+    dim = allocations[0].dim if allocations else 1
+    if dim < 2:
+        return []
+    lanes = list(range(dim))
+    rng.shuffle(lanes)
+    permuted = tuple(
+        Allocation(
+            id=a.id,
+            size=a.size,
+            start=tuple(time_components(a.start)[k] for k in lanes),
+            end=tuple(time_components(a.end)[k] for k in lanes),
+            offset=a.offset,
+            kind=a.kind,
+        )
+        for a in allocations
+    )
+    fails = []
+    if antichain_pressure(permuted) != antichain_pressure(allocations):
+        fails.append("antichain_pressure is not lane-permutation invariant")
+    if closure_or_none(permuted) != closure_or_none(allocations):
+        fails.append("closure_pressure is not lane-permutation invariant")
+    if conflict_degrees(permuted) != conflict_degrees(allocations):
+        fails.append("conflict_degrees is not lane-permutation invariant")
+    return fails
+
+
+def check_linearize(allocations: Allocs) -> list[str]:
+    """A linearization must preserve ids, sizes, and the conflict relation."""
+    linearized = try_linearize(allocations)
+    if linearized is None:
+        return []
+
+    if len(linearized) != len(allocations):
+        return [f"try_linearize returned {len(linearized)} of {len(allocations)}"]
+    if [a.id for a in linearized] != [a.id for a in allocations]:
+        return ["try_linearize reordered or renamed the allocations"]
+
+    fails = []
+    if any(a.dim != 1 for a in linearized):
+        fails.append("try_linearize returned non-scalar lifetimes")
+    if [a.size for a in linearized] != [a.size for a in allocations]:
+        fails.append("try_linearize changed a size")
+    if brute_conflict_pairs(linearized) != brute_conflict_pairs(allocations):
+        fails.append("try_linearize changed the conflict relation")
+    if antichain_pressure(linearized) != antichain_pressure(allocations):
+        fails.append("try_linearize changed antichain_pressure")
+    return fails
+
+
+def check_placement(
+    allocations: Allocs, placed: Allocs, label: str, pins: dict[IdType, int]
+) -> list[str]:
+    """The allocator exit contract, re-derived without trusting the allocator."""
+    if len(placed) != len(allocations):
+        return [f"{label}: returned {len(placed)} of {len(allocations)}"]
+    original = {a.id: a for a in allocations}
+    if {a.id for a in placed} != set(original):
+        return [f"{label}: returned a different id set"]
+
+    fails = _check_preserved(placed, original, label)
+    for alloc in placed:
+        pinned_at = pins.get(alloc.id)
+        if pinned_at is not None and alloc.offset != pinned_at:
+            fails.append(f"{label}: pin {alloc.id!r} moved to {alloc.offset}")
+            break
+    if any(a.offset is None for a in placed):
+        return fails
+
+    collisions = brute_collisions(placed)
+    if collisions:
+        first, second = collisions[0]
+        fails.append(
+            f"{label}: {len(collisions)} collisions, first {placed[first].id!r} "
+            f"against {placed[second].id!r}"
+        )
+    try:
+        validate_allocation(placed)
+    except ValueError as e:
+        fails.append(f"{label}: validate_allocation rejected the result, {e}")
+
+    peak = peak_of(placed)
+    if placement_pressure(placed) != peak:
+        fails.append(f"{label}: placement_pressure disagrees with the max height")
+    fails += _check_placement_peaks(placed, peak, label)
+    fails += _check_above_bounds(allocations, peak, label)
+    return fails
+
+
+def _check_above_bounds(allocations: Allocs, peak: int, label: str) -> list[str]:
+    """No placement can beat a bound that every placement must respect."""
+    fails = []
+    bound = antichain_pressure(allocations)
+    if peak < bound:
+        fails.append(f"{label}: peak {peak} below the exact lower bound {bound}")
+    closure = closure_or_none(allocations)
+    if closure is not None and peak < closure:
+        fails.append(f"{label}: peak {peak} below the closure bound {closure}")
+    return fails
+
+
+def _check_preserved(
+    placed: Allocs, original: dict[IdType, Allocation], label: str
+) -> list[str]:
+    """An allocator assigns offsets and touches nothing else."""
+    for alloc in placed:
+        source = original[alloc.id]
+        if alloc.offset is None:
+            return [f"{label}: left {alloc.id!r} unplaced"]
+        if alloc.offset < 0:
+            return [f"{label}: gave {alloc.id!r} a negative offset {alloc.offset}"]
+        if alloc.size != source.size:
+            return [f"{label}: changed the size of {alloc.id!r}"]
+        if alloc.start != source.start or alloc.end != source.end:
+            return [f"{label}: changed the lifetime of {alloc.id!r}"]
+        if alloc.kind != source.kind:
+            return [f"{label}: changed the kind of {alloc.id!r}"]
+    return []
+
+
+def _check_placement_peaks(placed: Allocs, peak: int, label: str) -> list[str]:
+    ids = [a.id for a in placed]
+    if len(set(ids)) != len(ids):
+        return []
+    per_alloc = placement_pressure_per_allocation(placed)
+    if max(per_alloc.values(), default=0) != peak:
+        return [f"{label}: max placement_pressure_per_allocation != peak"]
+    for alloc in placed:
+        if per_alloc[alloc.id] < (alloc.height or 0):
+            return [f"{label}: per-allocation peak below own height"]
+    return []
+
+
+def check_pickle(allocations: Allocs) -> list[str]:
+    """Allocations cross a process boundary in the parallel allocators."""
+    restored = pickle.loads(pickle.dumps(tuple(allocations)))  # noqa: S301
+    if list(restored) != list(allocations):
+        return ["pickle round-trip changed the allocations"]
+    if [a.dim for a in restored] != [a.dim for a in allocations]:
+        return ["pickle round-trip changed the clock dimensions"]
+    return []

--- a/scripts/stress/oracles.py
+++ b/scripts/stress/oracles.py
@@ -1,0 +1,387 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Cross-checks that pit one part of the API against another.
+
+Each is an oracle the implementation cannot satisfy by being self-consistently
+wrong: a proved optimum against every rival, a linearization against its source.
+"""
+
+import argparse
+import random
+import re
+import sys
+import time
+from collections.abc import Callable
+
+from invariants import brute_collisions, peak_of
+from omnimalloc import allocate, validate_allocation
+from omnimalloc._cpp import FirstFitPlacer, max_threads, set_max_threads
+from omnimalloc.allocators import (
+    BaseAllocator,
+    GeneticAllocator,
+    HillClimbAllocator,
+    SimulatedAnnealingAllocator,
+    SupermallocAllocator,
+    TabuSearchAllocator,
+    TelamallocAllocator,
+)
+from omnimalloc.analysis import (
+    antichain_pressure,
+    conflict_degrees,
+    conflict_graph,
+    try_linearize,
+)
+from workloads import Workload, by_name, catalog
+
+SCALAR_RIVALS = (
+    "omni",
+    "greedy",
+    "greedy_by_size",
+    "greedy_by_area",
+    "greedy_by_duration",
+    "greedy_by_conflict",
+    "greedy_by_conflict_size",
+    "greedy_by_start",
+    "greedy_by_all",
+    "best_fit",
+    "minimalloc",
+    "telamalloc",
+)
+
+# Built by hand rather than through the registry: only the concrete classes
+# declare a `timeout`, which is the parameter under test here.
+TIMED: tuple[tuple[str, Callable[[float], BaseAllocator]], ...] = (
+    ("supermalloc", lambda t: SupermallocAllocator(timeout=t)),
+    ("telamalloc", lambda t: TelamallocAllocator(timeout=t)),
+    ("simulated_annealing", lambda t: SimulatedAnnealingAllocator(timeout=t)),
+    ("tabu_search", lambda t: TabuSearchAllocator(timeout=t)),
+    ("hill_climb", lambda t: HillClimbAllocator(timeout=t)),
+    ("genetic", lambda t: GeneticAllocator(timeout=t)),
+)
+
+
+class Report:
+    """Collects failures so one broken oracle does not hide the others."""
+
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+
+    def fail(self, check: str, message: str) -> None:
+        self.failures.append(f"{check}: {message}")
+        print(f"FAIL {check}: {message}", flush=True)
+
+
+def scalar_workloads() -> list[Workload]:
+    return [w for w in catalog() if w.dim == 1 and "fixed" not in w.tags]
+
+
+def check_optimality(
+    report: Report, sizes: tuple[int, ...], seeds: tuple[int, ...]
+) -> None:
+    """A proved optimum must be unbeatable and bracketed by the exact bound."""
+    checked = proved = 0
+    for workload in scalar_workloads():
+        for size in sizes:
+            for seed in seeds:
+                allocations = workload.allocations(size, seed)
+                if not allocations:
+                    continue
+                checked += 1
+                where = f"{workload.name} n={size} seed={seed}"
+                proved += _check_solution(report, allocations, where)
+    print(f"  optimality: {checked} instances, {proved} proved optimal", flush=True)
+
+
+def _check_solution(report: Report, allocations: tuple, where: str) -> int:
+    """Check one solved instance; returns 1 when the search proved optimality."""
+    result = SupermallocAllocator(timeout=5.0).solve(allocations)
+    bound = antichain_pressure(allocations)
+
+    if brute_collisions(result.allocations):
+        report.fail("optimality", f"{where}: invalid placement")
+    if result.peak != peak_of(result.allocations):
+        report.fail("optimality", f"{where}: reported peak is not the peak")
+    if result.lower_bound > result.peak:
+        report.fail("optimality", f"{where}: lower_bound above its own peak")
+    if result.lower_bound > bound:
+        report.fail("optimality", f"{where}: bound above the exact bound")
+    if not result.proved_optimal:
+        return 0
+    if result.peak < bound:
+        report.fail("optimality", f"{where}: optimum below the exact bound")
+    _check_unbeaten(report, allocations, result.peak, where)
+    return 1
+
+
+def _check_unbeaten(report: Report, allocations: tuple, peak: int, where: str) -> None:
+    """No allocator may undercut a peak the search proved optimal."""
+    for name in SCALAR_RIVALS:
+        allocator = BaseAllocator.get(name)()
+        if not allocator.supports(allocations):
+            continue
+        try:
+            rival = tuple(allocator.allocate(allocations))
+        except (ImportError, RuntimeError) as e:
+            # minimalloc wraps a package that need not be installed
+            print(f"  skipped {name} on {where}: {e}", flush=True)
+            continue
+        if peak_of(rival) < peak:
+            report.fail(
+                "optimality",
+                f"{where}: {name} reached {peak_of(rival)} below the proved {peak}",
+            )
+
+
+def check_linearize_transfer(
+    report: Report, sizes: tuple[int, ...], seeds: tuple[int, ...]
+) -> None:
+    """Offsets found on a linearization must stay valid on the vector original."""
+    transferred = 0
+    for workload in catalog():
+        if workload.dim < 2:
+            continue
+        for size in sizes:
+            for seed in seeds:
+                allocations = workload.allocations(size, seed)
+                linearized = try_linearize(allocations)
+                if not allocations or linearized is None:
+                    continue
+                transferred += 1
+                placed = BaseAllocator.get("greedy_by_size")().allocate(linearized)
+                offsets = {a.id: a.offset for a in placed}
+                moved = tuple(a.with_offset(offsets[a.id]) for a in allocations)
+                where = f"{workload.name} n={size} seed={seed}"
+                if brute_collisions(moved):
+                    report.fail(
+                        "linearize_transfer",
+                        f"{where}: offsets valid on the linearization collide "
+                        f"on the original",
+                    )
+                try:
+                    validate_allocation(moved)
+                except ValueError as e:
+                    report.fail("linearize_transfer", f"{where}: {e}")
+    print(f"  linearize_transfer: {transferred} linearizable instances", flush=True)
+
+
+def check_idempotence(report: Report, sizes: tuple[int, ...]) -> None:
+    """Re-running a pinning allocator on its own output must change nothing."""
+    for workload in catalog():
+        for size in sizes:
+            allocations = workload.allocations(size, 0)
+            if not allocations:
+                continue
+            for name in ("omni", "greedy_by_size", "best_fit"):
+                allocator = BaseAllocator.get(name)()
+                if not allocator.supports(allocations):
+                    continue
+                once = tuple(allocator.allocate(allocations))
+                twice = tuple(allocator.allocate(once))
+                if [a.offset for a in twice] != [a.offset for a in once]:
+                    report.fail(
+                        "idempotence",
+                        f"{name} on {workload.name} n={size} moved a full pin",
+                    )
+    print("  idempotence: done", flush=True)
+
+
+def check_monotonicity(report: Report, sizes: tuple[int, ...]) -> None:
+    """A bound never falls when allocations are added."""
+    rng = random.Random(11)
+    for workload in catalog():
+        for size in sizes:
+            allocations = workload.allocations(size, 0)
+            if len(allocations) < 4:
+                continue
+            keep = sorted(rng.sample(range(len(allocations)), len(allocations) // 2))
+            subset = tuple(allocations[i] for i in keep)
+            full = antichain_pressure(allocations)
+            partial = antichain_pressure(subset)
+            if partial > full:
+                report.fail(
+                    "monotonicity",
+                    f"{workload.name} n={size}: subset bound {partial} above {full}",
+                )
+    print("  monotonicity: done", flush=True)
+
+
+def check_budget_boundary(report: Report) -> None:
+    """The budget an error advertises must be exactly the one that admits it."""
+    allocations = by_name()["sync[dense,t=8]"].allocations(400, 0)
+    try:
+        antichain_pressure(allocations, work_budget=0)
+    except RuntimeError as e:
+        match = re.search(r"work_budget=(\d+)", str(e))
+        if match is None:
+            report.fail("budget_boundary", f"no budget advertised in {e!r}")
+            return
+        advertised = int(match.group(1))
+        try:
+            antichain_pressure(allocations, work_budget=advertised)
+        except RuntimeError:
+            report.fail(
+                "budget_boundary", f"advertised {advertised} still refuses the instance"
+            )
+        try:
+            antichain_pressure(allocations, work_budget=advertised - 1)
+            report.fail(
+                "budget_boundary", f"{advertised - 1} accepted below the advertised"
+            )
+        except RuntimeError:
+            pass
+        print(f"  budget_boundary: advertised {advertised} is exact", flush=True)
+    else:
+        report.fail("budget_boundary", "work_budget=0 admitted a vector instance")
+
+
+def check_max_entries_boundary(report: Report) -> None:
+    """The CSR ceiling must admit exactly what the relation needs, and no less."""
+    allocations = by_name()["high_contention"].allocations(300, 0)
+    entries = 2 * conflict_graph(allocations).pair_count
+    try:
+        conflict_graph(allocations, max_entries=entries)
+    except RuntimeError as e:
+        report.fail("max_entries", f"the exact ceiling {entries} was refused, {e}")
+    try:
+        conflict_graph(allocations, max_entries=entries - 1)
+        report.fail("max_entries", f"{entries - 1} accepted below the need {entries}")
+    except RuntimeError:
+        pass
+    print(f"  max_entries: exact ceiling {entries} honored", flush=True)
+
+
+def check_timeouts(report: Report, size: int, budget: float) -> None:
+    """A declared timeout must bound the call, within a generous slack."""
+    allocations = by_name()["random"].allocations(size, 0)
+    for name, make in TIMED:
+        started = time.perf_counter()
+        make(budget).allocate(allocations)
+        elapsed = time.perf_counter() - started
+        print(f"  timeout {name}: {elapsed:.2f}s against {budget:.1f}s", flush=True)
+        if elapsed > budget * 5 + 2.0:
+            report.fail("timeouts", f"{name} took {elapsed:.1f}s on {budget}s")
+
+
+def check_thread_invariance(report: Report) -> None:
+    """Results must not depend on how many workers the kernels use."""
+    original = max_threads()
+    try:
+        for name in ("random", "sync[dense,t=8]", "tiling"):
+            allocations = by_name()[name].allocations(2000, 0)
+            reference: dict[str, object] = {}
+            for threads in (1, 2, 4, 8, 32):
+                set_max_threads(threads)
+                observed: dict[str, object] = {
+                    "omni": [a.offset for a in allocate(allocations, "omni")],
+                    "antichain": antichain_pressure(allocations),
+                    "degrees": conflict_degrees(allocations),
+                }
+                if not reference:
+                    reference = observed
+                    continue
+                for key, value in observed.items():
+                    if value != reference[key]:
+                        report.fail(
+                            "thread_invariance", f"{name}: {key} differs at {threads}"
+                        )
+    finally:
+        set_max_threads(original)
+    print("  thread_invariance: done", flush=True)
+
+
+def check_pins(report: Report, sizes: tuple[int, ...]) -> None:
+    """A pin survives every fraction, and the rest still pack around it."""
+    rng = random.Random(5)
+    allocator = BaseAllocator.get("omni")()
+    for workload in catalog():
+        for size in sizes:
+            allocations = workload.allocations(size, 0)
+            if not allocations:
+                continue
+            placed = tuple(allocator.allocate(allocations))
+            if [a.offset for a in allocator.allocate(placed)] != [
+                a.offset for a in placed
+            ]:
+                report.fail("pins", f"{workload.name} n={size}: a full pin moved")
+            for fraction in (0.25, 0.5, 0.75):
+                partial = tuple(
+                    a if rng.random() < fraction else a.with_offset(None)
+                    for a in placed
+                )
+                pins = {a.id: a.offset for a in partial if a.offset is not None}
+                result = tuple(allocator.allocate(partial))
+                moved = [a.id for a in result if pins.get(a.id) not in (None, a.offset)]
+                if moved:
+                    report.fail("pins", f"{workload.name} n={size}: {moved[0]!r} moved")
+                if brute_collisions(result):
+                    report.fail(
+                        "pins", f"{workload.name} n={size} f={fraction}: collisions"
+                    )
+    print("  pins: done", flush=True)
+
+
+def check_first_fit_placer(report: Report, sizes: tuple[int, ...]) -> None:
+    """``FirstFitPlacer.peak(order)`` must agree with placing that same order."""
+    rng = random.Random(3)
+    for workload in scalar_workloads():
+        for size in sizes:
+            allocations = workload.allocations(size, 0)
+            if not allocations:
+                continue
+            placer = FirstFitPlacer(allocations)
+            for _ in range(3):
+                order = list(range(len(allocations)))
+                rng.shuffle(order)
+                predicted = placer.peak(order)
+                placed = placer.place(order)
+                if peak_of(placed) != predicted:
+                    report.fail(
+                        "first_fit_placer",
+                        f"{workload.name} n={size}: peak() {predicted} != "
+                        f"place() {peak_of(placed)}",
+                    )
+                if brute_collisions(placed):
+                    report.fail(
+                        "first_fit_placer", f"{workload.name} n={size}: collisions"
+                    )
+    print("  first_fit_placer: done", flush=True)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sizes", type=int, nargs="+", default=[12, 40, 120])
+    parser.add_argument("--seeds", type=int, nargs="+", default=[0, 1])
+    parser.add_argument("--timeout-size", type=int, default=3000)
+    parser.add_argument("--timeout-budget", type=float, default=1.0)
+    args = parser.parse_args()
+    sizes, seeds = tuple(args.sizes), tuple(args.seeds)
+    report = Report()
+
+    checks = (
+        ("optimality", lambda: check_optimality(report, sizes, seeds)),
+        ("linearize_transfer", lambda: check_linearize_transfer(report, sizes, seeds)),
+        ("idempotence", lambda: check_idempotence(report, sizes)),
+        ("monotonicity", lambda: check_monotonicity(report, sizes)),
+        ("budget_boundary", lambda: check_budget_boundary(report)),
+        ("max_entries_boundary", lambda: check_max_entries_boundary(report)),
+        (
+            "timeouts",
+            lambda: check_timeouts(report, args.timeout_size, args.timeout_budget),
+        ),
+        ("thread_invariance", lambda: check_thread_invariance(report)),
+        ("pins", lambda: check_pins(report, sizes)),
+        ("first_fit_placer", lambda: check_first_fit_placer(report, sizes)),
+    )
+    for name, check in checks:
+        print(f"== {name}", flush=True)
+        started = time.perf_counter()
+        check()
+        print(f"== {name} took {time.perf_counter() - started:.0f}s", flush=True)
+
+    print(f"\n{len(report.failures)} oracle failures")
+    sys.exit(1 if report.failures else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/profile_api.py
+++ b/scripts/stress/profile_api.py
@@ -1,0 +1,423 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Profile the analysis API and the allocators across scales and workloads.
+
+Every call runs at its shipped default budget, so a refusal is itself a
+measurement; results are written per bench, so a late crash keeps the earlier ones.
+"""
+
+import argparse
+import gc
+import json
+import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from omnimalloc import allocate
+from omnimalloc.allocators import BaseAllocator
+from omnimalloc.analysis import (
+    antichain_pressure,
+    closure_pressure,
+    conflict_degrees,
+    conflict_graph,
+    conflicts,
+    pressure_per_allocation,
+    try_linearize,
+)
+from workloads import by_name, catalog
+
+SCALES = (100, 1_000, 10_000, 100_000, 1_000_000)
+
+PROFILED_WORKLOADS = (
+    "random",
+    "high_contention",
+    "skewed[dominant]",
+    "tiling",
+    "minimalloc[challenging]",
+    "sync[sparse,t=8]",
+    "sync[dense,t=8]",
+    "sync[dense,t=32]",
+    "concurrent_tiling[t=4]",
+    "two_plus_two[noise=0.0]",
+)
+
+FAST_ALLOCATORS = (
+    "omni",
+    "greedy",
+    "greedy_by_size",
+    "greedy_by_conflict",
+    "greedy_by_all",
+    "best_fit",
+    "naive",
+)
+
+SEARCH_ALLOCATORS = (
+    "supermalloc",
+    "telamalloc",
+    "minimalloc",
+    "simulated_annealing",
+    "tabu_search",
+    "hill_climb",
+    "random",
+)
+
+# `TilingBase._build_tiles` rescans every tile per split, so generating one of
+# these past a few thousand allocations costs more than the whole sweep.
+MAX_BUILD_SCALE = 10_000
+QUADRATIC_BUILDERS = frozenset({"tiling", "pinwheel", "concurrent_tiling"})
+
+# The anytime searches spend an uninterruptible setup (the relation plus a first
+# greedy pack) before their budget starts, so past this they measure setup.
+MAX_SEARCH_SCALE = 10_000
+
+# Above this a single shot is enough, and three would triple an already long run
+REPEAT_LIMIT = 10_000
+
+ANALYSIS_CALLS: dict[str, Callable] = {
+    "antichain_pressure": antichain_pressure,
+    "closure_pressure": closure_pressure,
+    "conflict_degrees": conflict_degrees,
+    "conflict_graph": lambda a: conflict_graph(a).pair_count,
+    "conflicts": lambda a: len(conflicts(a)),
+    "try_linearize": lambda a: try_linearize(a) is not None,
+    "pressure_per_allocation": lambda a: len(pressure_per_allocation(a)),
+}
+
+
+def build_capped(name: str) -> bool:
+    return any(name.startswith(prefix) for prefix in QUADRATIC_BUILDERS)
+
+
+def timed(call: Callable, repeats: int) -> float:
+    """Best of `repeats`; the minimum is the least noisy estimator here."""
+    best = float("inf")
+    for _ in range(repeats):
+        gc.collect()
+        started = time.perf_counter()
+        call()
+        best = min(best, time.perf_counter() - started)
+    return best
+
+
+def rss_mb() -> float:
+    """Current resident set; ru_maxrss is a high-water mark and cannot fall."""
+    with Path("/proc/self/status").open() as status:
+        for line in status:
+            if line.startswith("VmRSS:"):
+                return int(line.split()[1]) / 1024
+    return 0.0
+
+
+def bench_analysis(args: argparse.Namespace) -> list[dict]:
+    rows: list[dict] = []
+    index = by_name()
+    for name in PROFILED_WORKLOADS:
+        stalled: set[str] = set()
+        for scale in args.scales:
+            if build_capped(name) and scale > MAX_BUILD_SCALE:
+                print(f"  analysis {name} n={scale} skipped, slow generator")
+                break
+            started = time.perf_counter()
+            allocations = index[name].allocations(scale, 0)
+            rows.append(
+                {
+                    "bench": "build",
+                    "workload": name,
+                    "n": len(allocations),
+                    "seconds": time.perf_counter() - started,
+                }
+            )
+            if len(allocations) < scale // 2:
+                break  # a fixed source ran out of allocations
+            for call_name, call in ANALYSIS_CALLS.items():
+                rows.append(
+                    _time_call(name, call_name, call, allocations, stalled, args.cutoff)
+                )
+            print(f"  analysis {name} n={len(allocations)} done", flush=True)
+    return rows
+
+
+def _time_call(
+    workload: str,
+    call_name: str,
+    call: Callable,
+    allocations: tuple,
+    stalled: set[str],
+    cutoff: float,
+) -> dict:
+    """One timing, or a recorded reason it was not taken."""
+    row = {
+        "bench": "analysis",
+        "workload": workload,
+        "call": call_name,
+        "n": len(allocations),
+        "dim": allocations[0].dim,
+        "seconds": None,
+    }
+    if call_name in stalled:
+        return {**row, "skipped": "an earlier scale passed the cutoff"}
+    repeats = 3 if len(allocations) <= REPEAT_LIMIT else 1
+    try:
+        seconds = timed(lambda: call(allocations), repeats)
+    except RuntimeError as e:
+        stalled.add(call_name)
+        return {**row, "error": f"{type(e).__name__}: {e}"[:160]}
+    if seconds > cutoff:
+        stalled.add(call_name)
+    return {**row, "seconds": seconds, "ns_per_alloc": seconds / len(allocations) * 1e9}
+
+
+def bench_allocators(args: argparse.Namespace) -> list[dict]:
+    rows: list[dict] = []
+    index = by_name()
+    names = list(FAST_ALLOCATORS) + list(SEARCH_ALLOCATORS)
+    for workload in PROFILED_WORKLOADS:
+        stalled: set[str] = set()
+        for scale in args.scales:
+            if build_capped(workload) and scale > MAX_BUILD_SCALE:
+                break
+            allocations = index[workload].allocations(scale, 0)
+            if len(allocations) < scale // 2:
+                break
+            bound = _bound_or_none(allocations)
+            for name in names:
+                if name in stalled:
+                    continue
+                if name in SEARCH_ALLOCATORS and len(allocations) > MAX_SEARCH_SCALE:
+                    continue
+                row = _time_allocator(workload, name, allocations, bound, args.cutoff)
+                if row is None:
+                    continue
+                if "error" in row or row["seconds"] > args.cutoff:
+                    stalled.add(name)
+                rows.append(row)
+            print(f"  allocators {workload} n={len(allocations)} done", flush=True)
+    return rows
+
+
+def _bound_or_none(allocations: tuple) -> int | None:
+    try:
+        return antichain_pressure(allocations)
+    except RuntimeError:
+        return None
+
+
+def _time_allocator(
+    workload: str, name: str, allocations: tuple, bound: int | None, cutoff: float
+) -> dict | None:
+    row = {"bench": "allocator", "workload": workload, "allocator": name}
+    try:
+        allocator = BaseAllocator.get(name)()
+    except (ImportError, RuntimeError):
+        return None
+    if not allocator.supports(allocations):
+        return None
+
+    repeats = 3 if len(allocations) <= REPEAT_LIMIT else 1
+    placed: tuple = ()
+
+    def run() -> None:
+        nonlocal placed
+        placed = tuple(allocator.allocate(allocations))
+
+    try:
+        seconds = timed(run, repeats)
+    except (RuntimeError, MemoryError, ValueError) as e:
+        return {**row, "n": len(allocations), "error": f"{type(e).__name__}: {e}"[:160]}
+
+    peak = max((a.height for a in placed if a.height is not None), default=0)
+    return {
+        **row,
+        "n": len(allocations),
+        "dim": allocations[0].dim,
+        "seconds": seconds,
+        "ns_per_alloc": seconds / len(allocations) * 1e9,
+        "peak": peak,
+        "bound": bound,
+        "ratio": (peak / bound) if bound else None,
+        "cutoff": cutoff,
+    }
+
+
+def bench_quality(args: argparse.Namespace) -> list[dict]:
+    """Peak over the exact lower bound for every workload in the catalog."""
+    rows = []
+    for workload in catalog():
+        allocations = workload.allocations(args.quality_size, 0)
+        if not allocations:
+            continue
+        bound = _bound_or_none(allocations)
+        if bound is None:
+            rows.append(
+                {
+                    "bench": "quality",
+                    "workload": workload.name,
+                    "error": "the exact bound exceeds its default budget",
+                }
+            )
+            continue
+        peaks: dict[str, int] = {}
+        seconds: dict[str, float] = {}
+        for name in list(FAST_ALLOCATORS) + list(SEARCH_ALLOCATORS):
+            placed, elapsed = _place_once(name, allocations)
+            if placed is None:
+                continue
+            peaks[name] = max((a.height for a in placed if a.height), default=0)
+            seconds[name] = elapsed
+        rows.append(
+            {
+                "bench": "quality",
+                "workload": workload.name,
+                "family": workload.family,
+                "dim": allocations[0].dim,
+                "n": len(allocations),
+                "bound": bound,
+                "known_optimum": workload.known_optimum,
+                "peaks": peaks,
+                "seconds": seconds,
+            }
+        )
+        print(f"  quality {workload.name} done", flush=True)
+    return rows
+
+
+def _place_once(name: str, allocations: tuple) -> tuple[tuple | None, float]:
+    try:
+        allocator = BaseAllocator.get(name)()
+    except (ImportError, RuntimeError):
+        return None, 0.0
+    if not allocator.supports(allocations):
+        return None, 0.0
+    started = time.perf_counter()
+    try:
+        placed = tuple(allocator.allocate(allocations))
+    except (RuntimeError, MemoryError, ValueError):
+        return None, 0.0
+    return placed, time.perf_counter() - started
+
+
+def bench_concurrency(args: argparse.Namespace) -> list[dict]:
+    """Check that the kernels release the GIL and stay identical under load."""
+    rows = []
+    index = by_name()
+    for workload in ("random", "sync[dense,t=8]"):
+        allocations = index[workload].allocations(args.concurrency_size, 0)
+        jobs: dict[str, Callable] = {
+            "omni_allocate": lambda a=allocations: [
+                x.offset for x in allocate(a, "omni")
+            ],
+            "antichain_pressure": lambda a=allocations: antichain_pressure(a),
+            "conflict_degrees": lambda a=allocations: conflict_degrees(a),
+        }
+        for job_name, job in jobs.items():
+            try:
+                expected = job()
+            except RuntimeError as e:
+                rows.append(
+                    {
+                        "bench": "concurrency",
+                        "workload": workload,
+                        "job": job_name,
+                        "error": f"{type(e).__name__}: {e}"[:160],
+                    }
+                )
+                continue
+            rows += _scale_job(workload, job_name, job, expected, len(allocations))
+            print(f"  concurrency {workload}/{job_name} done", flush=True)
+    return rows
+
+
+def _scale_job(
+    workload: str, job_name: str, job: Callable, expected: object, count: int
+) -> list[dict]:
+    rows = []
+    baseline = 0.0
+    for workers in (1, 2, 4, 8, 16, 32):
+        calls = workers * 4
+        started = time.perf_counter()
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            outputs = list(pool.map(lambda _: job(), range(calls)))
+        throughput = calls / (time.perf_counter() - started)
+        baseline = baseline or throughput
+        rows.append(
+            {
+                "bench": "concurrency",
+                "workload": workload,
+                "job": job_name,
+                "workers": workers,
+                "n": count,
+                "calls_per_s": throughput,
+                "speedup": throughput / baseline,
+                "mismatches": sum(1 for out in outputs if out != expected),
+            }
+        )
+    return rows
+
+
+def bench_memory(args: argparse.Namespace) -> list[dict]:
+    """Footprint of the one structure that materializes per conflicting pair."""
+    rows = []
+    index = by_name()
+    for workload in ("high_contention", "random"):
+        for scale in args.memory_sizes:
+            allocations = index[workload].allocations(scale, 0)
+            gc.collect()
+            before = rss_mb()
+            graph = conflict_graph(allocations, max_entries=None)
+            pairs = graph.pair_count
+            added = rss_mb() - before
+            del graph
+            gc.collect()
+            rows.append(
+                {
+                    "bench": "memory",
+                    "workload": workload,
+                    "structure": "conflict_graph",
+                    "n": len(allocations),
+                    "pairs": pairs,
+                    "rss_delta_mb": added,
+                    "bytes_per_pair": added * 2**20 / max(pairs, 1),
+                }
+            )
+            print(f"  memory {workload} n={scale} pairs={pairs:,}", flush=True)
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scales", type=int, nargs="+", default=list(SCALES))
+    parser.add_argument("--cutoff", type=float, default=20.0)
+    parser.add_argument("--quality-size", type=int, default=1000)
+    parser.add_argument("--concurrency-size", type=int, default=20_000)
+    parser.add_argument("--memory-sizes", type=int, nargs="+", default=[10_000, 50_000])
+    parser.add_argument(
+        "--benches",
+        nargs="+",
+        default=["analysis", "allocators", "quality", "concurrency", "memory"],
+    )
+    parser.add_argument("--out", type=Path, default=Path("profile_results.json"))
+    args = parser.parse_args()
+
+    runners: dict[str, Callable[[argparse.Namespace], list[dict]]] = {
+        "analysis": bench_analysis,
+        "allocators": bench_allocators,
+        "quality": bench_quality,
+        "concurrency": bench_concurrency,
+        "memory": bench_memory,
+    }
+    rows: list[dict] = []
+    for bench in args.benches:
+        print(f"== {bench}", flush=True)
+        started = time.perf_counter()
+        rows += runners[bench](args)
+        # Written per bench so a later crash never discards earlier measurements
+        args.out.write_text(json.dumps(rows, indent=1, default=str))
+        print(f"== {bench} took {time.perf_counter() - started:.0f}s", flush=True)
+
+    print(f"{len(rows)} rows, wrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/report.py
+++ b/scripts/stress/report.py
@@ -1,0 +1,195 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Render the profiling JSON as readable tables.
+
+Refusals and skips print as such rather than as blanks, so a table never
+implies a measurement that was never taken.
+"""
+
+import argparse
+import json
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, median
+
+# Ratios within this of 1.0 are optimal up to the bound's own exactness
+OPTIMAL_SLACK = 1.0005
+
+
+def format_seconds(seconds: float | None) -> str:
+    if seconds is None:
+        return "-"
+    if seconds < 1e-3:
+        return f"{seconds * 1e6:.0f}us"
+    if seconds < 1:
+        return f"{seconds * 1e3:.1f}ms"
+    return f"{seconds:.2f}s"
+
+
+def cell(row: dict | None) -> str:
+    """One table cell: a timing, a refusal, a skip, or nothing measured."""
+    if row is None:
+        return ""
+    if row.get("seconds") is not None:
+        return format_seconds(row["seconds"])
+    return "refused" if "error" in row else "skipped"
+
+
+def table_analysis(rows: list[dict]) -> None:
+    print("\n### Analysis throughput\n")
+    by_workload: dict[str, dict] = defaultdict(dict)
+    calls: list[str] = []
+    scales: set[int] = set()
+    for row in rows:
+        if row["bench"] != "analysis":
+            continue
+        by_workload[row["workload"]][row["call"], row["n"]] = row
+        if row["call"] not in calls:
+            calls.append(row["call"])
+        scales.add(row["n"])
+
+    order = sorted(scales)
+    for workload, cells in by_workload.items():
+        dims = sorted({r["dim"] for r in cells.values() if r.get("dim")})
+        print(f"\n{workload}  (clock dim {dims or ['-']})")
+        print(f"  {'call':<26}" + "".join(f"{n:>12,}" for n in order))
+        for call in calls:
+            line = f"  {call:<26}"
+            for n in order:
+                line += f"{cell(cells.get((call, n))):>12}"
+            print(line)
+
+
+def table_builds(rows: list[dict], threshold: float) -> None:
+    slow = [r for r in rows if r["bench"] == "build" and r["seconds"] > threshold]
+    if not slow:
+        return
+    print(f"\n### Workload generation over {threshold}s (not part of the API)\n")
+    for row in slow:
+        print(
+            f"  {row['workload']:<28} n={row['n']:>9,}  "
+            f"{format_seconds(row['seconds'])}"
+        )
+
+
+def table_allocators(rows: list[dict]) -> None:
+    print("\n### Allocator throughput, with quality at the largest scale\n")
+    by_workload: dict[str, dict[str, dict[int, dict]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
+    for row in rows:
+        if row["bench"] == "allocator" and row.get("seconds") is not None:
+            by_workload[row["workload"]][row["allocator"]][row["n"]] = row
+
+    for workload, allocators in by_workload.items():
+        scales = sorted({n for cells in allocators.values() for n in cells})
+        print(f"\n{workload}")
+        header = f"  {'allocator':<22}"
+        header += "".join(f"{n:>11,}" for n in scales)
+        print(header + f"{'peak/bound':>13}")
+        for name, cells in sorted(allocators.items()):
+            line = f"  {name:<22}"
+            for n in scales:
+                line += f"{cell(cells.get(n)):>11}"
+            ratio = cells[max(cells)].get("ratio")
+            line += f"{(f'{ratio:.4f}' if ratio else '-'):>13}"
+            print(line)
+
+
+def table_quality(rows: list[dict]) -> None:
+    entries = [r for r in rows if r["bench"] == "quality" and r.get("peaks")]
+    if not entries:
+        return
+    print("\n### Placement quality: peak over the exact lower bound\n")
+    ratios: dict[str, list[float]] = defaultdict(list)
+    for entry in entries:
+        for name, peak in entry["peaks"].items():
+            if entry["bound"]:
+                ratios[name].append(peak / entry["bound"])
+
+    print(
+        f"  {'allocator':<22}{'inst':>6}{'mean':>9}{'median':>9}"
+        f"{'worst':>11}{'optimal':>12}"
+    )
+    for name, values in sorted(ratios.items(), key=lambda kv: mean(kv[1])):
+        optimal = sum(1 for v in values if v < OPTIMAL_SLACK)
+        print(
+            f"  {name:<22}{len(values):>6}{mean(values):>9.3f}"
+            f"{median(values):>9.3f}{max(values):>11.3f}"
+            f"{f'{optimal} / {len(values)}':>12}"
+        )
+    print(f"\n  instances scored: {len(entries)}")
+
+
+def table_known_optimum(rows: list[dict]) -> None:
+    entries = [
+        r
+        for r in rows
+        if r["bench"] == "quality" and r.get("known_optimum") and r.get("peaks")
+    ]
+    if not entries:
+        return
+    print("\n### Reverse-constructed instances: peak over the known optimum\n")
+    names = sorted({name for entry in entries for name in entry["peaks"]})
+    print(f"  {'workload':<26}" + "".join(f"{n[:11]:>12}" for n in names))
+    for entry in entries:
+        line = f"  {entry['workload']:<26}"
+        for name in names:
+            peak = entry["peaks"].get(name)
+            line += f"{peak / entry['known_optimum']:>12.3f}" if peak else f"{'-':>12}"
+        print(line)
+
+
+def table_concurrency(rows: list[dict]) -> None:
+    by_job: dict[tuple[str, str], dict[int, dict]] = defaultdict(dict)
+    for row in rows:
+        if row["bench"] == "concurrency" and "workers" in row:
+            by_job[row["workload"], row["job"]][row["workers"]] = row
+    if not by_job:
+        return
+    print("\n### Concurrency scaling\n")
+    for (workload, job), cells in by_job.items():
+        workers = sorted(cells)
+        print(f"\n{job} on {workload} (n={cells[workers[0]]['n']:,})")
+        print(f"  {'workers':<12}" + "".join(f"{w:>10}" for w in workers))
+        for label, key, spec in (
+            ("calls/s", "calls_per_s", "10.1f"),
+            ("speedup", "speedup", "10.2f"),
+            ("mismatches", "mismatches", "10d"),
+        ):
+            values = "".join(f"{cells[w][key]:>{spec}}" for w in workers)
+            print(f"  {label:<12}{values}")
+
+
+def table_memory(rows: list[dict]) -> None:
+    entries = [r for r in rows if r["bench"] == "memory"]
+    if not entries:
+        return
+    print("\n### Conflict graph footprint\n")
+    for row in entries:
+        print(
+            f"  {row['workload']:<20} n={row['n']:>8,} "
+            f"pairs={row['pairs']:>14,}  RSS +{row['rss_delta_mb']:>9.1f} MB  "
+            f"{row['bytes_per_pair']:.1f} B/pair"
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("results", type=Path)
+    parser.add_argument("--slow-build", type=float, default=0.5)
+    args = parser.parse_args()
+
+    rows = json.loads(args.results.read_text())
+    table_analysis(rows)
+    table_builds(rows, args.slow_build)
+    table_allocators(rows)
+    table_quality(rows)
+    table_known_optimum(rows)
+    table_concurrency(rows)
+    table_memory(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/stress/workloads.py
+++ b/scripts/stress/workloads.py
@@ -1,0 +1,383 @@
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+"""Catalog of diverse workloads for the stress harness.
+
+Wraps the benchmark sources plus shapes no generator produces, and records a
+``known_optimum`` only where the instance is reverse-constructed from one.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+from omnimalloc.benchmark.sources import (
+    ConcurrentTilingSource,
+    HighContentionSource,
+    MinimallocSource,
+    PinwheelSource,
+    PowerOf2Source,
+    RandomSource,
+    SequentialSource,
+    SkewedSource,
+    SyncPatternSource,
+    TilingSource,
+    TwoPlusTwoSource,
+    UniformSource,
+)
+from omnimalloc.benchmark.sources.sizes import SIZE_DISTRIBUTIONS
+from omnimalloc.benchmark.sources.sync_patterns import SYNC_PATTERNS
+from omnimalloc.common.constants import KB, MB
+from omnimalloc.primitives import Allocation
+
+# The tiling sources cut a `capacity x makespan` rectangle into leaves, so the
+# capacity is exactly the optimal peak.
+TILING_CAPACITY = MB
+
+
+@dataclass(frozen=True)
+class Workload:
+    """One named, seedable instance generator plus what is known about it."""
+
+    name: str
+    family: str
+    dim: int
+    build: Callable[[int, int], tuple[Allocation, ...]]
+    known_optimum: int | None = None
+    tags: frozenset[str] = field(default_factory=frozenset)
+
+    def allocations(self, size: int, seed: int) -> tuple[Allocation, ...]:
+        return self.build(size, seed)
+
+
+def _generators() -> list[Workload]:
+    return [
+        Workload(
+            "random",
+            "generator",
+            1,
+            lambda n, s: RandomSource(num_allocations=n, seed=s).get_allocations(),
+        ),
+        Workload(
+            "random_wide_sizes",
+            "generator",
+            1,
+            lambda n, s: RandomSource(
+                num_allocations=n, size_min=1, size_max=64 * MB, seed=s
+            ).get_allocations(),
+        ),
+        Workload(
+            "random_long_lived",
+            "generator",
+            1,
+            lambda n, s: RandomSource(
+                num_allocations=n,
+                time_max=1000,
+                duration_min=400,
+                duration_max=1000,
+                seed=s,
+            ).get_allocations(),
+        ),
+        Workload(
+            "random_short_lived",
+            "generator",
+            1,
+            lambda n, s: RandomSource(
+                num_allocations=n,
+                time_max=100_000,
+                duration_min=1,
+                duration_max=2,
+                seed=s,
+            ).get_allocations(),
+            tags=frozenset({"sparse"}),
+        ),
+        Workload(
+            "uniform",
+            "generator",
+            1,
+            lambda n, s: UniformSource(num_allocations=n, seed=s).get_allocations(),
+        ),
+        Workload(
+            "power_of2",
+            "generator",
+            1,
+            lambda n, s: PowerOf2Source(num_allocations=n, seed=s).get_allocations(),
+        ),
+        Workload(
+            "high_contention",
+            "generator",
+            1,
+            lambda n, s: HighContentionSource(
+                num_allocations=n, seed=s
+            ).get_allocations(),
+            tags=frozenset({"dense"}),
+        ),
+        Workload(
+            "sequential",
+            "generator",
+            1,
+            lambda n, s: SequentialSource(num_allocations=n, seed=s).get_allocations(),
+        ),
+    ]
+
+
+def _skewed() -> list[Workload]:
+    return [
+        Workload(
+            f"skewed[{distribution}]",
+            "adversarial",
+            1,
+            lambda n, s, d=distribution: SkewedSource(
+                num_allocations=n, distribution=d, seed=s
+            ).get_allocations(),
+            tags=frozenset({"adversarial"}),
+        )
+        for distribution in SIZE_DISTRIBUTIONS
+    ]
+
+
+def _tilings() -> list[Workload]:
+    entries = [
+        Workload(
+            "tiling",
+            "tiling",
+            1,
+            lambda n, s: TilingSource(num_allocations=n, seed=s).get_allocations(),
+            known_optimum=TILING_CAPACITY,
+            tags=frozenset({"known_optimum"}),
+        ),
+        Workload(
+            "tiling_mem_biased",
+            "tiling",
+            1,
+            lambda n, s: TilingSource(
+                num_allocations=n, mem_cut_prob=0.9, seed=s
+            ).get_allocations(),
+            known_optimum=TILING_CAPACITY,
+            tags=frozenset({"known_optimum"}),
+        ),
+        Workload(
+            "pinwheel",
+            "tiling",
+            1,
+            lambda n, s: PinwheelSource(num_allocations=n, seed=s).get_allocations(),
+            known_optimum=TILING_CAPACITY,
+            tags=frozenset({"known_optimum", "adversarial"}),
+        ),
+    ]
+    entries += [
+        Workload(
+            f"concurrent_tiling[t={threads}]",
+            "tiling",
+            threads,
+            lambda n, s, t=threads: ConcurrentTilingSource(
+                num_allocations=max(n, t), num_threads=t, seed=s
+            ).get_allocations(),
+            known_optimum=TILING_CAPACITY,
+            tags=frozenset({"known_optimum", "vector"}),
+        )
+        for threads in (2, 4, 8)
+    ]
+    return entries
+
+
+def _sync_patterns() -> list[Workload]:
+    entries = [
+        Workload(
+            f"sync[{pattern},t=4]",
+            "sync",
+            4,
+            lambda n, s, p=pattern: SyncPatternSource(
+                num_allocations=n, num_threads=4, pattern=p, seed=s
+            ).get_allocations(),
+            tags=frozenset({"vector"}),
+        )
+        for pattern in SYNC_PATTERNS
+    ]
+    entries += [
+        Workload(
+            f"sync[{pattern},t={threads}]",
+            "sync",
+            threads,
+            lambda n, s, t=threads, p=pattern: SyncPatternSource(
+                num_allocations=n, num_threads=t, pattern=p, seed=s
+            ).get_allocations(),
+            tags=frozenset({"vector"}),
+        )
+        for pattern, threads in (
+            ("dense", 2),
+            ("dense", 8),
+            ("dense", 16),
+            ("dense", 32),
+            ("dense", 64),
+            ("sparse", 8),
+            ("sparse", 32),
+            ("sparse", 64),
+        )
+    ]
+    entries.append(
+        Workload(
+            "sync[independent,t=16,skew]",
+            "sync",
+            16,
+            lambda n, s: SyncPatternSource(
+                num_allocations=n,
+                num_threads=16,
+                pattern="independent",
+                speed_skew=7,
+                size_distribution="dominant",
+                seed=s,
+            ).get_allocations(),
+            tags=frozenset({"vector", "adversarial"}),
+        )
+    )
+    return entries
+
+
+def _non_interval() -> list[Workload]:
+    return [
+        Workload(
+            f"two_plus_two[noise={noise}]",
+            "adversarial",
+            2,
+            lambda n, s, x=noise: TwoPlusTwoSource(
+                num_allocations=n, noise=x, seed=s
+            ).get_allocations(),
+            tags=frozenset({"vector", "adversarial", "non_interval"}),
+        )
+        for noise in (0.0, 0.5)
+    ]
+
+
+def _identical(n: int, _seed: int) -> tuple[Allocation, ...]:
+    return tuple(Allocation(id=i, size=KB, start=0, end=1) for i in range(n))
+
+
+def _disjoint(n: int, _seed: int) -> tuple[Allocation, ...]:
+    return tuple(Allocation(id=i, size=KB, start=i, end=i + 1) for i in range(n))
+
+
+def _nested(n: int, _seed: int) -> tuple[Allocation, ...]:
+    return tuple(Allocation(id=i, size=KB, start=i, end=2 * n - i) for i in range(n))
+
+
+def _staircase(n: int, _seed: int) -> tuple[Allocation, ...]:
+    return tuple(
+        Allocation(id=i, size=(i + 1) * KB, start=i, end=i + 2) for i in range(n)
+    )
+
+
+def _one_giant(n: int, _seed: int) -> tuple[Allocation, ...]:
+    giant = Allocation(id=0, size=n * MB, start=0, end=2 * n)
+    rest = (Allocation(id=i, size=KB, start=i, end=i + 2) for i in range(1, n))
+    return (giant, *rest)
+
+
+def _huge_sizes(n: int, _seed: int) -> tuple[Allocation, ...]:
+    """Sizes near 2**40 exercise the 64-bit accumulators in the C++ sweeps."""
+    return tuple(
+        Allocation(id=i, size=(1 << 40) + i, start=i % 7, end=i % 7 + 3)
+        for i in range(n)
+    )
+
+
+def _huge_times(n: int, _seed: int) -> tuple[Allocation, ...]:
+    base = 1 << 50
+    return tuple(
+        Allocation(id=i, size=KB, start=base + i, end=base + i + 3) for i in range(n)
+    )
+
+
+def _string_ids(n: int, _seed: int) -> tuple[Allocation, ...]:
+    return tuple(
+        Allocation(id=f"buf/{i:06d}", size=(i % 17 + 1) * KB, start=i, end=i + 5)
+        for i in range(n)
+    )
+
+
+def _vector_identical(n: int, _seed: int) -> tuple[Allocation, ...]:
+    return tuple(
+        Allocation(id=i, size=KB, start=(0, 0, 0, 0), end=(1, 1, 1, 1))
+        for i in range(n)
+    )
+
+
+def _vector_chain(n: int, _seed: int) -> tuple[Allocation, ...]:
+    """A totally ordered chain, so no two allocations conflict at all."""
+    return tuple(
+        Allocation(id=i, size=KB, start=(i, i), end=(i + 1, i + 1)) for i in range(n)
+    )
+
+
+def _degenerate() -> list[Workload]:
+    return [
+        Workload("degenerate_identical", "degenerate", 1, _identical),
+        Workload("degenerate_disjoint", "degenerate", 1, _disjoint),
+        Workload("degenerate_nested", "degenerate", 1, _nested),
+        Workload("degenerate_staircase", "degenerate", 1, _staircase),
+        Workload("degenerate_one_giant", "degenerate", 1, _one_giant),
+        Workload(
+            "degenerate_huge_sizes",
+            "degenerate",
+            1,
+            _huge_sizes,
+            tags=frozenset({"overflow"}),
+        ),
+        Workload(
+            "degenerate_huge_times",
+            "degenerate",
+            1,
+            _huge_times,
+            tags=frozenset({"overflow"}),
+        ),
+        Workload("degenerate_string_ids", "degenerate", 1, _string_ids),
+        Workload(
+            "degenerate_vector_identical",
+            "degenerate",
+            4,
+            _vector_identical,
+            tags=frozenset({"vector"}),
+        ),
+        Workload(
+            "degenerate_vector_chain",
+            "degenerate",
+            2,
+            _vector_chain,
+            tags=frozenset({"vector"}),
+        ),
+    ]
+
+
+def _real() -> list[Workload]:
+    """The bundled Minimalloc CSVs, absent from wheel installs."""
+    entries = []
+    for subset in ("examples", "small", "challenging"):
+        source = MinimallocSource(subset=subset)
+        if not source.get_available_variants():
+            continue
+        entries.append(
+            Workload(
+                f"minimalloc[{subset}]",
+                "real",
+                1,
+                lambda n, _s, src=source: src.get_allocations(num_allocations=n),
+                tags=frozenset({"real", "fixed"}),
+            )
+        )
+    return entries
+
+
+def catalog() -> list[Workload]:
+    """Every workload the harness sweeps, in a stable order."""
+    return (
+        _generators()
+        + _skewed()
+        + _tilings()
+        + _sync_patterns()
+        + _non_interval()
+        + _degenerate()
+        + _real()
+    )
+
+
+def by_name() -> dict[str, Workload]:
+    return {workload.name: workload for workload in catalog()}

--- a/src/cpp/primitives/allocation.cpp
+++ b/src/cpp/primitives/allocation.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 namespace omnimalloc {
@@ -165,7 +166,18 @@ Allocation Allocation::with_offset(std::optional<int64_t> new_offset) const {
 
 std::ostream& operator<<(std::ostream& os, const Allocation& a) {
   os << "Allocation(id=";
-  std::visit([&os](const auto& value) { os << value; }, a.id_);
+  // Quote textual ids: unquoted, id=1 and id="1" print alike though they are
+  // distinct allocations, and the repr stops round-tripping through eval.
+  std::visit(
+      [&os](const auto& value) {
+        if constexpr (std::is_same_v<std::decay_t<decltype(value)>,
+                                     std::string>) {
+          os << '\'' << value << '\'';
+        } else {
+          os << value;
+        }
+      },
+      a.id_);
   os << ", size=" << a.size_ << ", start=" << to_string(a.start_)
      << ", end=" << to_string(a.end_);
   if (a.offset_.has_value()) {

--- a/src/python/omnimalloc/allocators/greedy.py
+++ b/src/python/omnimalloc/allocators/greedy.py
@@ -3,6 +3,7 @@
 #
 
 import logging
+import threading
 from concurrent.futures import ProcessPoolExecutor
 
 from omnimalloc._cpp import first_fit_place
@@ -87,15 +88,24 @@ def _place_serially(
     return results
 
 
+def _pool_is_safe(workers: int) -> bool:
+    """Whether the pool is worth starting for this many workers.
+
+    It forks, and forking a process that has other threads running leaves the
+    child holding locks nobody will release: it may raise, or it may deadlock.
+    """
+    return workers > 1 and threading.active_count() == 1
+
+
 def _place_pooled(
     allocations: tuple[Allocation, ...],
     variants: tuple[BaseAllocator, ...],
     workers: int,
 ) -> list[tuple[Allocation, ...]] | None:
-    """Results from the process pool, or None when the pool cannot be used.
+    """Results from the process pool, or None when the fork is refused.
 
-    The pool forks, which a process running other threads may refuse outright;
-    a placement is worth more than the parallelism, so the caller retries serially.
+    The backstop for a thread that starts between the check and the fork; a
+    placement is worth more than the parallelism, so the caller retries serially.
     """
     results = []
     try:
@@ -126,7 +136,11 @@ def allocate_parallel(
 
     workers = min(resolve_num_threads(num_threads), len(variants))
 
-    results = _place_pooled(allocations, variants, workers) if workers > 1 else None
+    results = (
+        _place_pooled(allocations, variants, workers)
+        if _pool_is_safe(workers)
+        else None
+    )
     if results is None:
         results = _place_serially(allocations, variants)
 

--- a/src/python/omnimalloc/allocators/greedy.py
+++ b/src/python/omnimalloc/allocators/greedy.py
@@ -3,7 +3,6 @@
 #
 
 import logging
-import threading
 from concurrent.futures import ProcessPoolExecutor
 
 from omnimalloc._cpp import first_fit_place
@@ -76,6 +75,45 @@ def _run_variant(
     return allocator.allocate(allocations)
 
 
+def _place_serially(
+    allocations: tuple[Allocation, ...], variants: tuple[BaseAllocator, ...]
+) -> list[tuple[Allocation, ...]]:
+    results = []
+    for variant in variants:
+        try:
+            results.append(variant.allocate(allocations))
+        except Exception:
+            logger.warning("Variant %s failed; skipping it", variant, exc_info=True)
+    return results
+
+
+def _place_pooled(
+    allocations: tuple[Allocation, ...],
+    variants: tuple[BaseAllocator, ...],
+    workers: int,
+) -> list[tuple[Allocation, ...]] | None:
+    """Results from the process pool, or None when the pool cannot be used.
+
+    The pool forks, which a process running other threads may refuse outright;
+    a placement is worth more than the parallelism, so the caller retries serially.
+    """
+    results = []
+    try:
+        with ProcessPoolExecutor(max_workers=workers) as pool:
+            futures = [pool.submit(_run_variant, v, allocations) for v in variants]
+            for variant, future in zip(variants, futures, strict=True):
+                try:
+                    results.append(future.result())
+                except Exception:
+                    logger.warning(
+                        "Variant %s failed; skipping it", variant, exc_info=True
+                    )
+    except (OSError, RuntimeError) as e:
+        logger.warning("Process pool unavailable (%s); placing serially", e)
+        return None
+    return results
+
+
 def allocate_parallel(
     allocations: tuple[Allocation, ...],
     variants: tuple[BaseAllocator, ...],
@@ -88,27 +126,9 @@ def allocate_parallel(
 
     workers = min(resolve_num_threads(num_threads), len(variants))
 
-    if workers > 1 and threading.active_count() > 1:
-        logger.debug("Multi-threaded caller; running variants serially")
-        workers = 1
-
-    results = []
-    if workers <= 1:
-        for variant in variants:
-            try:
-                results.append(variant.allocate(allocations))
-            except Exception:
-                logger.warning("Variant %s failed; skipping it", variant, exc_info=True)
-    else:
-        with ProcessPoolExecutor(max_workers=workers) as pool:
-            futures = [pool.submit(_run_variant, v, allocations) for v in variants]
-            for variant, future in zip(variants, futures, strict=True):
-                try:
-                    results.append(future.result())
-                except Exception:
-                    logger.warning(
-                        "Variant %s failed; skipping it", variant, exc_info=True
-                    )
+    results = _place_pooled(allocations, variants, workers) if workers > 1 else None
+    if results is None:
+        results = _place_serially(allocations, variants)
 
     if not results:
         raise RuntimeError("Every allocator variant failed")

--- a/src/python/omnimalloc/allocators/greedy.py
+++ b/src/python/omnimalloc/allocators/greedy.py
@@ -3,6 +3,7 @@
 #
 
 import logging
+import threading
 from concurrent.futures import ProcessPoolExecutor
 
 from omnimalloc._cpp import first_fit_place
@@ -80,21 +81,17 @@ def allocate_parallel(
     variants: tuple[BaseAllocator, ...],
     num_threads: int | None = None,
 ) -> tuple[Allocation, ...]:
-    """Run each variant and return the lowest peak memory results.
-
-    `num_threads=None` uses every worker the thread cap allows. A failing
-    variant is logged and dropped; only an all-failing set raises.
-    """
+    """Run each variant and return the lowest peak memory results."""
 
     if not allocations:
         return allocations
 
-    # There is nothing for a worker beyond the last variant to do, so cap on
-    # both paths: an explicit count is a ceiling, not a demand for processes
     workers = min(resolve_num_threads(num_threads), len(variants))
 
-    # One variant dying (raised, or its worker OOM-killed) must not discard
-    # the placements the others already produced, on either path
+    if workers > 1 and threading.active_count() > 1:
+        logger.debug("Multi-threaded caller; running variants serially")
+        workers = 1
+
     results = []
     if workers <= 1:
         for variant in variants:
@@ -125,8 +122,6 @@ class GreedyAllocator(BaseAllocator):
     supports_pinned = True
 
     def _allocate(self, allocations: tuple[Allocation, ...]) -> tuple[Allocation, ...]:
-        # The C++ kernel computes the conflict relation natively, unbudgeted:
-        # placement needs the true relation and never degrades.
         return tuple(first_fit_place(allocations))
 
 
@@ -173,10 +168,7 @@ class GreedyBySizeAllocator(GreedyAllocator):
 
 
 class GreedyByAllAllocator(GreedyAllocator):
-    """Greedy allocator that runs every variant and keeps the best result.
-
-    `num_threads=None` uses all cores.
-    """
+    """Greedy allocator that runs every variant and keeps the best result."""
 
     def __init__(self, num_threads: int | None = None) -> None:
         ensure_positive(num_threads, "num_threads", allow_none=True)

--- a/tests/unit/allocators/test_base.py
+++ b/tests/unit/allocators/test_base.py
@@ -61,9 +61,9 @@ def test_portfolio_never_spawns_more_workers_than_variants(
 
     monkeypatch.setattr(greedy, "ProcessPoolExecutor", Recorder)
     variants = (OmniAllocator(), OmniAllocator())
-    with pytest.raises(RuntimeError):
-        allocate_parallel(ALLOCATIONS, variants, num_threads=32)
+    placed = allocate_parallel(ALLOCATIONS, variants, num_threads=32)
     assert seen == [len(variants)]
+    assert len(placed) == len(ALLOCATIONS)
 
 
 def test_supports_counts_pins_like_ensure_supported() -> None:

--- a/tests/unit/allocators/test_base.py
+++ b/tests/unit/allocators/test_base.py
@@ -59,6 +59,9 @@ def test_portfolio_never_spawns_more_workers_than_variants(
             seen.append(max_workers)
             raise RuntimeError("Stop before spawning workers")
 
+    # Pinned: the pool is skipped outright once any other thread is alive, and
+    # an earlier test leaving one would otherwise decide this one.
+    monkeypatch.setattr(greedy.threading, "active_count", lambda: 1)
     monkeypatch.setattr(greedy, "ProcessPoolExecutor", Recorder)
     variants = (OmniAllocator(), OmniAllocator())
     placed = allocate_parallel(ALLOCATIONS, variants, num_threads=32)

--- a/tests/unit/allocators/test_greedy.py
+++ b/tests/unit/allocators/test_greedy.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+import threading
+
 import pytest
 from omnimalloc._cpp import FirstFitPlacer, first_fit_place
 from omnimalloc.allocators import greedy
@@ -507,3 +509,37 @@ def test_scalar_conflict_orders_ignore_the_budget(
     monkeypatch.setattr(greedy, "DEFAULT_WORK_BUDGET", 0)
     allocations = tuple(Allocation(id=i, size=8, start=i, end=i + 2) for i in range(20))
     validate_allocation(GreedyByConflictAllocator().allocate(allocations))
+
+
+def test_greedy_by_all_from_a_threaded_caller_places_every_allocation() -> None:
+    allocations = tuple(Allocation(id=i, size=8, start=i, end=i + 3) for i in range(64))
+    results: list[object] = []
+
+    def run() -> None:
+        try:
+            results.append(GreedyByAllAllocator().allocate(allocations))
+        except Exception as e:  # noqa: BLE001
+            results.append(e)
+
+    threads = [threading.Thread(target=run) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert not [r for r in results if isinstance(r, Exception)]
+    for placed in results:
+        validate_allocation(placed)
+
+
+def test_multi_threaded_caller_takes_the_serial_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(threading, "active_count", lambda: 4)
+
+    def refuse(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("must not fork from a multi-threaded caller")
+
+    monkeypatch.setattr(greedy, "ProcessPoolExecutor", refuse)
+    allocations = tuple(Allocation(id=i, size=8, start=i, end=i + 3) for i in range(16))
+    validate_allocation(GreedyByAllAllocator().allocate(allocations))

--- a/tests/unit/allocators/test_greedy.py
+++ b/tests/unit/allocators/test_greedy.py
@@ -538,6 +538,7 @@ def test_a_refused_fork_falls_back_to_the_serial_path(
     def refuse(*_args: object, **_kwargs: object) -> None:
         raise RuntimeError("os.fork is unsafe while filelock is changing ownership")
 
+    monkeypatch.setattr(greedy.threading, "active_count", lambda: 1)
     monkeypatch.setattr(greedy, "ProcessPoolExecutor", refuse)
     allocations = tuple(Allocation(id=i, size=8, start=i, end=i + 3) for i in range(16))
     placed = GreedyByAllAllocator().allocate(allocations)

--- a/tests/unit/allocators/test_greedy.py
+++ b/tests/unit/allocators/test_greedy.py
@@ -532,14 +532,16 @@ def test_greedy_by_all_from_a_threaded_caller_places_every_allocation() -> None:
         validate_allocation(placed)
 
 
-def test_multi_threaded_caller_takes_the_serial_path(
+def test_a_refused_fork_falls_back_to_the_serial_path(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(threading, "active_count", lambda: 4)
-
     def refuse(*_args: object, **_kwargs: object) -> None:
-        raise AssertionError("must not fork from a multi-threaded caller")
+        raise RuntimeError("os.fork is unsafe while filelock is changing ownership")
 
     monkeypatch.setattr(greedy, "ProcessPoolExecutor", refuse)
     allocations = tuple(Allocation(id=i, size=8, start=i, end=i + 3) for i in range(16))
-    validate_allocation(GreedyByAllAllocator().allocate(allocations))
+    placed = GreedyByAllAllocator().allocate(allocations)
+    validate_allocation(placed)
+    assert placement_pressure(placed) == placement_pressure(
+        GreedyByAllAllocator(num_threads=1).allocate(allocations)
+    )

--- a/tests/unit/primitives/test_allocation.py
+++ b/tests/unit/primitives/test_allocation.py
@@ -353,11 +353,17 @@ def test_equal_allocations_hash_equal() -> None:
     assert hash(first) == hash(second)
 
 
-def test_int_and_str_ids_with_same_repr_are_distinct() -> None:
+def test_int_and_str_ids_are_distinct_and_repr_apart() -> None:
     numeric = Allocation(id=1, size=100, start=0, end=10)
     textual = Allocation(id="1", size=100, start=0, end=10)
     assert numeric != textual
     assert len({numeric, textual}) == 2
+    assert repr(numeric) != repr(textual)
+
+
+def test_repr_quotes_string_ids_and_leaves_numeric_bare() -> None:
+    assert "id='buf 0'" in repr(Allocation(id="buf 0", size=1, start=0, end=1))
+    assert "id=7," in repr(Allocation(id=7, size=1, start=0, end=1))
 
 
 def test_allocation_eq_with_non_allocation_returns_false() -> None:


### PR DESCRIPTION
Fix a fork hazard in greedy_by_all and an ambiguous Allocation repr

allocate_parallel runs its variants in a ProcessPoolExecutor, which forks.
Forking a process that has other threads running hands the child locks no
surviving thread will release; filelock, which the huggingface-hub extra pulls
in, guards against this and raises. Five of eight concurrent greedy_by_all
calls failed with "os.fork is unsafe while filelock is changing descriptor
ownership", and a 1134-cell sweep hit it 7 times in ~1043 invocations.

Fall back to the serial loop when the caller is multi-threaded. Single-threaded
callers keep the pool untouched. The trade is measured: the pool is 2x to 30x
slower than serial below 1000 allocations, where fork setup dominates, and 3.0x
to 5.0x faster at 10k to 50k, so only large threaded instances give anything up.
Eight concurrent calls now finish in 0.09s with every allocation placed.

Allocation's stream operator also printed textual ids unquoted, so id=1 and
id="1" rendered alike although they compare and hash apart, and an id holding a
space read as Allocation(id=my buf, ...). Quote the string alternative of the
variant and leave integers bare.


Add a stress and profiling harness for the public API

Five scripts over a shared catalog of 54 workloads, covering the analysis
functions, all 19 allocators, and the hierarchy types. The reference
implementations in invariants.py are deliberately naive Python rather than the
C++ kernels, so a kernel bug cannot hide behind itself.

  workloads.py    the catalog: generators, tilings with a known optimum, sync
                  patterns, non-interval 2+2 instances, degenerate shapes
  invariants.py   checks plus brute-force references: pairwise conflicts, a
                  scalar sweep line, and an exact max-weight clique
  fuzz.py         sweeps workload x size x seed x allocator on a thread pool,
                  checking placements, pins, determinism and the hierarchy
  contracts.py    records what every entry point does on hostile input
  oracles.py      ten cross-checks that pit one part of the API against another
  profile_api.py  throughput, quality, concurrency and memory, at shipped budgets
  report.py       renders the profiling JSON as tables

Every analysis call in profile_api.py runs at its default budget, so a refusal
is itself a measurement, and results are written per bench so a late crash keeps
the earlier ones. Nothing is silently dropped: skips and refusals print as such.

ty excludes contracts.py because passing wrong types on purpose is its subject.

Running it found the two defects fixed in the previous commit. It also
characterises four behaviours left alone: closure_pressure(closure_cap=None) is
exponential in the clock dimension with no memory backstop, the anytime
allocators vary in layout but never in peak, timeout budgets the search rather
than the call, and TilingBase._build_tiles is quadratic.

