### PR TITLE
Skip a rate limited example instead of failing the run

### DIFF
--- a/tests/integration/test_examples.py
+++ b/tests/integration/test_examples.py
@@ -11,6 +11,7 @@ from omnimalloc.common.directories import EXAMPLES_DIR
 
 EXAMPLE_FILES = sorted(EXAMPLES_DIR.glob("*.py"))
 TIMEOUT_SECONDS = 600  # 10 minutes
+RATE_LIMIT_MARKERS = ("429 Too Many Requests", "huggingface.co")
 
 
 @pytest.mark.parametrize("example_file", EXAMPLE_FILES, ids=lambda p: p.name)
@@ -25,6 +26,8 @@ def test_examples(example_file: Path, tmp_path: Path) -> None:
     )
 
     if result.returncode != 0:
+        if all(marker in result.stderr for marker in RATE_LIMIT_MARKERS):
+            pytest.skip("Hugging Face Hub rate limited the request")
         print(f"\n=== STDOUT ===\n{result.stdout}")
         print(f"\n=== STDERR ===\n{result.stderr}")
         pytest.fail(f"Example {example_file.name} failed with code {result.returncode}")


### PR DESCRIPTION
One matrix job of a run for #50 was throttled by the Hugging Face Hub,
which answered 429 to the model listing, so 04_sources and 05_benchmark
exited non-zero and the run went red. Parallel CI jobs share GitHub
Actions IP ranges, and #62 already conceded that losing the rate limit
lottery says nothing about the code.

That fix covered the five tests that reach the Hub in-process, where the
status code is on the exception. The examples run in a subprocess, so the
only evidence that crosses the boundary is the traceback the child wrote,
and the check has to read it: a 429 against huggingface.co in stderr
skips, anything else still prints both streams and fails.